### PR TITLE
Jacoco 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 group = 'sixgaezzang'
@@ -42,6 +43,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    finalizedBy jacocoTestReport
+}
+
+// Checkstyle
+checkstyle {
+    maxWarnings = 0
 }
 
 tasks.withType(Checkstyle) {
@@ -51,6 +59,54 @@ tasks.withType(Checkstyle) {
     }
 }
 
-checkstyle {
-    maxWarnings = 0
+// Jacoco
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+    dependsOn test
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            includes = [
+                'sixgaezzang/sidepeek/**/service/*'
+            ]
+        }
+
+        rule {
+            element = 'METHOD'
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 50
+            }
+        }
+    }
+
+    dependsOn jacocoTestReport
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Closes #7

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [X] Jacoco 세팅
  - 우선 브랜치랑 라인 커버리지 `service` 디렉토리에 있는 파일만 **80%** 채우도록 설정했습니다! 
  - **메서드**는 나중에 저희 작성하면서 너무 길어지는 것만 미리 잡아 놓으면 좋을 것 같아서 **50줄**까지로만 설정해놓았습니다! 개발하다가 조금 더 늘려야겠다 싶으면 편하게 말씀해주시면 감사하겠습니당!

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 저번에 jacoco 결과를 PR 댓글(+ 슬랙 알림)로 달리도록 했던 것이 편해서 요번에도 나중에 가능하면 적용해보려고 합니다! 다만 `✅ 테스트해봤어유` 태그가 달리는 경우에만 테스트를 진행하도록 설정해보면 좋을 것 같아서 저도 틈틈이 github actions 조금 더 공부해오겠습니다!