### PR TITLE
기술 스택 및 회원 닉네임 검색 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     // SpringBoot
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     // SpringBoot
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/domain/ProjectSkill.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/domain/ProjectSkill.java
@@ -13,7 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sixgaezzang.sidepeek.common.domain.Skill;
+import sixgaezzang.sidepeek.skill.domain.Skill;
 
 @Entity
 @Table(name = "project_skill")

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -1,0 +1,28 @@
+package sixgaezzang.sidepeek.skill.controller;
+
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
+import sixgaezzang.sidepeek.skill.serivce.SkillService;
+
+@RestController
+@RequestMapping("/skills")
+@RequiredArgsConstructor
+public class SkillController {
+    private final SkillService skillService;
+
+    @GetMapping
+    public ResponseEntity<SkillSearchResponse> searchByName(
+        @RequestParam(required = false)
+        @Size(max = 50, message = "최대 50자의 키워드로 검색할 수 있습니다.")
+        String keyword
+    ) {
+        return ResponseEntity.ok()
+            .body(skillService.searchByName(keyword));
+    }
+}

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -14,6 +14,7 @@ import sixgaezzang.sidepeek.skill.serivce.SkillService;
 @RequestMapping("/skills")
 @RequiredArgsConstructor
 public class SkillController {
+
     private final SkillService skillService;
 
     @GetMapping
@@ -25,4 +26,5 @@ public class SkillController {
         return ResponseEntity.ok()
             .body(skillService.searchByName(keyword));
     }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.common.domain;
+package sixgaezzang.sidepeek.skill.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillResponse.java
@@ -1,0 +1,11 @@
+package sixgaezzang.sidepeek.skill.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SkillResponse(
+    Long id,
+    String name,
+    String iconImageUrl
+) {
+}

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillResponse.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.skill.dto;
 
 import lombok.Builder;
+import sixgaezzang.sidepeek.skill.domain.Skill;
 
 @Builder
 public record SkillResponse(
@@ -8,4 +9,13 @@ public record SkillResponse(
     String name,
     String iconImageUrl
 ) {
+
+    public static SkillResponse from(Skill skill) {
+        return SkillResponse.builder()
+            .id(skill.getId())
+            .name(skill.getName())
+            .iconImageUrl(skill.getIconImageUrl())
+            .build();
+    }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillSearchResponse.java
@@ -1,8 +1,18 @@
 package sixgaezzang.sidepeek.skill.dto;
 
 import java.util.List;
+import sixgaezzang.sidepeek.skill.domain.Skill;
 
 public record SkillSearchResponse(
     List<SkillResponse> skills
 ) {
+
+    public static SkillSearchResponse from(List<Skill> skills) {
+        List<SkillResponse> skillResponses = skills.stream()
+            .map(SkillResponse::from)
+            .toList();
+
+        return new SkillSearchResponse(skillResponses);
+    }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/SkillSearchResponse.java
@@ -1,0 +1,8 @@
+package sixgaezzang.sidepeek.skill.dto;
+
+import java.util.List;
+
+public record SkillSearchResponse(
+    List<SkillResponse> skills
+) {
+}

--- a/src/main/java/sixgaezzang/sidepeek/skill/repository/SkillRepository.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/repository/SkillRepository.java
@@ -1,0 +1,10 @@
+package sixgaezzang.sidepeek.skill.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import sixgaezzang.sidepeek.skill.domain.Skill;
+
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+
+    List<Skill> findAllByNameContaining(String keyword);
+}

--- a/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
@@ -6,12 +6,14 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.skill.domain.Skill;
 import sixgaezzang.sidepeek.skill.dto.SkillResponse;
 import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
 import sixgaezzang.sidepeek.skill.repository.SkillRepository;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SkillService {
 

--- a/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
@@ -2,13 +2,10 @@ package sixgaezzang.sidepeek.skill.serivce;
 
 import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
 
-import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sixgaezzang.sidepeek.skill.domain.Skill;
-import sixgaezzang.sidepeek.skill.dto.SkillResponse;
 import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
 import sixgaezzang.sidepeek.skill.repository.SkillRepository;
 
@@ -22,23 +19,14 @@ public class SkillService {
     private final SkillRepository skillRepository;
 
     public SkillSearchResponse searchByName(String keyword) {
-        List<Skill> skills;
         if (Objects.isNull(keyword) || keyword.isBlank()) {
-            skills = skillRepository.findAll();
-        } else {
-            validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
-                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
-            skills = skillRepository.findAllByNameContaining(keyword);
+            return SkillSearchResponse.from(skillRepository.findAll());
         }
 
-        List<SkillResponse> searchResults = skills.stream()
-            .map(skill -> SkillResponse.builder()
-                .id(skill.getId())
-                .name(skill.getName())
-                .iconImageUrl(skill.getIconImageUrl())
-                .build()
-            ).toList();
+        validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
+                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
 
-        return new SkillSearchResponse(searchResults);
+        return SkillSearchResponse.from(skillRepository.findAllByNameContaining(keyword));
     }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
@@ -1,0 +1,42 @@
+package sixgaezzang.sidepeek.skill.serivce;
+
+import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
+
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sixgaezzang.sidepeek.skill.domain.Skill;
+import sixgaezzang.sidepeek.skill.dto.SkillResponse;
+import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
+import sixgaezzang.sidepeek.skill.repository.SkillRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SkillService {
+
+    public static final int KEYWORD_MAX_LENGTH = 50;
+
+    private final SkillRepository skillRepository;
+
+    public SkillSearchResponse searchByName(String keyword) {
+        List<Skill> skills;
+        if (Objects.isNull(keyword) || keyword.isBlank()) {
+            skills = skillRepository.findAll();
+        } else {
+            validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
+                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+            skills = skillRepository.findAllByNameContaining(keyword);
+        }
+
+        List<SkillResponse> searchResults = skills.stream()
+            .map(skill -> SkillResponse.builder()
+                .id(skill.getId())
+                .name(skill.getName())
+                .iconImageUrl(skill.getIconImageUrl())
+                .build()
+            ).toList();
+
+        return new SkillSearchResponse(searchResults);
+    }
+}

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -1,16 +1,20 @@
 package sixgaezzang.sidepeek.users.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.dto.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.UserSearchResponse;
 import sixgaezzang.sidepeek.users.service.UserService;
 
 @RestController
@@ -29,5 +33,15 @@ public class UserController {
 
         return ResponseEntity.created(uri)
             .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<UserSearchResponse> searchByNickname(
+        @RequestParam(required = false)
+        @Size(max = 20, message = "최대 20자의 키워드로 검색할 수 있습니다.")
+        String keyword
+    ) {
+        return ResponseEntity.ok()
+            .body(userService.searchByNickname(keyword));
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -44,4 +44,5 @@ public class UserController {
         return ResponseEntity.ok()
             .body(userService.searchByNickname(keyword));
     }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/domain/UserSkill.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/domain/UserSkill.java
@@ -13,7 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sixgaezzang.sidepeek.common.domain.Skill;
+import sixgaezzang.sidepeek.skill.domain.Skill;
 
 @Entity
 @Table(name = "user_skill")

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/UserSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/UserSearchResponse.java
@@ -1,0 +1,8 @@
+package sixgaezzang.sidepeek.users.dto;
+
+import java.util.List;
+
+public record UserSearchResponse(
+    List<UserSummaryResponse> users
+) {
+}

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/UserSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/UserSearchResponse.java
@@ -1,8 +1,18 @@
 package sixgaezzang.sidepeek.users.dto;
 
 import java.util.List;
+import sixgaezzang.sidepeek.users.domain.User;
 
 public record UserSearchResponse(
     List<UserSummaryResponse> users
 ) {
+
+    public static UserSearchResponse from(List<User> users) {
+        List<UserSummaryResponse> userSummaryResponses = users.stream()
+            .map(UserSummaryResponse::from)
+            .toList();
+
+        return new UserSearchResponse(userSummaryResponses);
+    }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/UserSummaryResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/UserSummaryResponse.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.users.dto;
 
 import lombok.Builder;
+import sixgaezzang.sidepeek.users.domain.User;
 
 @Builder
 public record UserSummaryResponse(
@@ -8,4 +9,13 @@ public record UserSummaryResponse(
     String nickname,
     String profileImageUrl
 ) {
+
+    public static UserSummaryResponse from(User user) {
+        return UserSummaryResponse.builder()
+            .id(user.getId())
+            .nickname(user.getNickname())
+            .profileImageUrl(user.getProfileImageUrl())
+            .build();
+    }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/UserSummaryResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/UserSummaryResponse.java
@@ -1,0 +1,11 @@
+package sixgaezzang.sidepeek.users.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserSummaryResponse(
+    Long id,
+    String nickname,
+    String profileImageUrl
+) {
+}

--- a/src/main/java/sixgaezzang/sidepeek/users/repository/UserRepository.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package sixgaezzang.sidepeek.users.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sixgaezzang.sidepeek.users.domain.User;
 
@@ -8,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    List<User> findAllByNicknameContaining(String keyword);
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -1,6 +1,10 @@
 package sixgaezzang.sidepeek.users.service;
 
+import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
+
 import jakarta.persistence.EntityExistsException;
+import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -9,12 +13,16 @@ import sixgaezzang.sidepeek.users.domain.Password;
 import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.UserSearchResponse;
+import sixgaezzang.sidepeek.users.dto.UserSummaryResponse;
 import sixgaezzang.sidepeek.users.repository.UserRepository;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final int KEYWORD_MAX_LENGTH = 20;
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -38,6 +46,27 @@ public class UserService {
         User saved = userRepository.save(user);
 
         return saved.getId();
+    }
+
+    public UserSearchResponse searchByNickname(String keyword) {
+        List<User> users;
+        if (Objects.isNull(keyword) || keyword.isBlank()) {
+            users = userRepository.findAll();
+        } else {
+            validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
+                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+            users = userRepository.findAllByNicknameContaining(keyword);
+        }
+
+        List<UserSummaryResponse> searchResults = users.stream()
+            .map(user -> UserSummaryResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build()
+            ).toList();
+
+        return new UserSearchResponse(searchResults);
     }
 
     private void verifyUniqueNickname(SignUpRequest request) {

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -3,7 +3,6 @@ package sixgaezzang.sidepeek.users.service;
 import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
 
 import jakarta.persistence.EntityExistsException;
-import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,7 +13,6 @@ import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.SignUpRequest;
 import sixgaezzang.sidepeek.users.dto.UserSearchResponse;
-import sixgaezzang.sidepeek.users.dto.UserSummaryResponse;
 import sixgaezzang.sidepeek.users.repository.UserRepository;
 
 @Service
@@ -49,24 +47,14 @@ public class UserService {
     }
 
     public UserSearchResponse searchByNickname(String keyword) {
-        List<User> users;
         if (Objects.isNull(keyword) || keyword.isBlank()) {
-            users = userRepository.findAll();
-        } else {
-            validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
-                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
-            users = userRepository.findAllByNicknameContaining(keyword);
+            return UserSearchResponse.from(userRepository.findAll());
         }
 
-        List<UserSummaryResponse> searchResults = users.stream()
-            .map(user -> UserSummaryResponse.builder()
-                .id(user.getId())
-                .nickname(user.getNickname())
-                .profileImageUrl(user.getProfileImageUrl())
-                .build()
-            ).toList();
+        validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
+                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
 
-        return new UserSearchResponse(searchResults);
+        return UserSearchResponse.from(userRepository.findAllByNicknameContaining(keyword));
     }
 
     private void verifyUniqueNickname(SignUpRequest request) {


### PR DESCRIPTION
This reverts commit 61d76e021279d1e78b94a120029c28f10bb3e0b3.

## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #38 
Resolves #33 
Resolves #30 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 기술 스택 검색 api 구현
- [x] 회원 닉네임 검색 api 구현

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 코드 PR이 꼬여버려서 두 가지 기능을 같이 올리게 되었습니다.,. 죄송합니다.. 
  - 작동하는 것도 확인하고 올립니다!
  - 두 기능 구조가 비슷해서 같이 작업했는데 앞으론 하나 제대로 하고 브랜치 따로 둬서 해야겠습니다...😇
- **두 기능 모두 프로젝트 게시글 저장 페이지에서 각각 스택 검색, 회원 검색에 이용하는 api 입니다!**
  - 위 상황을 고려해서 쿼리스트링을 안 보낼 때는 전체 목록이 나오게 하고 keyword(검색어)가 주어질 때는 검색어가 포함된 이름을 가진 각각의 객체들이 반환되도록 구현했습니다!
- 테스트 코드와 swagger 설정은 저도 나중에 나눠서 올리겠습니다!