### PR TITLE
기술 스택 및 회원 닉네임 검색 api 리팩토링 및 테스트

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -1,5 +1,7 @@
 package sixgaezzang.sidepeek.skill.controller;
 
+import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,7 +28,7 @@ public class SkillController {
     @Parameter(name = "keyword", description = "검색어", example = "spring")
     public ResponseEntity<SkillSearchResponse> searchByName(
         @RequestParam(required = false)
-        @Size(max = 50, message = "최대 50자의 키워드로 검색할 수 있습니다.")
+        @Size(max = MAX_SKILL_NAME_LENGTH, message = "최대 " + MAX_SKILL_NAME_LENGTH + "자의 키워드로 검색할 수 있습니다.")
         String keyword
     ) {
         return ResponseEntity.ok()

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
+import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
 import sixgaezzang.sidepeek.skill.serivce.SkillService;
 
 @RestController

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.skill.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +21,9 @@ public class SkillController {
     private final SkillService skillService;
 
     @GetMapping
+    @Operation(summary = "기술 스택 검색")
+    @ApiResponse(responseCode = "200", description = "기술 스택 검색 성공")
+    @Parameter(name = "keyword", description = "검색어", example = "spring")
     public ResponseEntity<SkillSearchResponse> searchByName(
         @RequestParam(required = false)
         @Size(max = 50, message = "최대 50자의 키워드로 검색할 수 있습니다.")

--- a/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.skill.domain;
 
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
+import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateURI;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -35,6 +36,7 @@ public class Skill {
     public Skill(String name, String iconImageUrl) {
         validateMaxLength(name, MAX_SKILL_NAME_LENGTH,
             "최대 " + MAX_SKILL_NAME_LENGTH + "자의 이름으로 생성할 수 있습니다.");
+        validateURI(iconImageUrl, "이미지 url 형식이 올바르지 않습니다.");
 
         this.name = name;
         this.iconImageUrl = iconImageUrl;

--- a/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
@@ -16,11 +16,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Skill {
 
+    public static final int MAX_SKILL_NAME_LENGTH = 50;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name", nullable = false, length = 50)
+    @Column(name = "name", nullable = false, length = MAX_SKILL_NAME_LENGTH)
     private String name;
 
     @Column(name = "icon_image_url", nullable = false, columnDefinition = "TEXT")

--- a/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/domain/Skill.java
@@ -1,5 +1,7 @@
 package sixgaezzang.sidepeek.skill.domain;
 
+import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -7,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,5 +30,14 @@ public class Skill {
 
     @Column(name = "icon_image_url", nullable = false, columnDefinition = "TEXT")
     private String iconImageUrl;
+
+    @Builder
+    public Skill(String name, String iconImageUrl) {
+        validateMaxLength(name, MAX_SKILL_NAME_LENGTH,
+            "최대 " + MAX_SKILL_NAME_LENGTH + "자의 이름으로 생성할 수 있습니다.");
+
+        this.name = name;
+        this.iconImageUrl = iconImageUrl;
+    }
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillResponse.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.skill.dto;
+package sixgaezzang.sidepeek.skill.dto.response;
 
 import lombok.Builder;
 import sixgaezzang.sidepeek.skill.domain.Skill;

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillSearchResponse.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.skill.dto;
+package sixgaezzang.sidepeek.skill.dto.response;
 
 import java.util.List;
 import sixgaezzang.sidepeek.skill.domain.Skill;

--- a/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
@@ -1,12 +1,12 @@
 package sixgaezzang.sidepeek.skill.serivce;
 
-import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
+import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
 
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sixgaezzang.sidepeek.skill.dto.SkillSearchResponse;
+import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
 import sixgaezzang.sidepeek.skill.repository.SkillRepository;
 
 @Service

--- a/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/serivce/SkillService.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.skill.serivce;
 
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
+import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
 
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,6 @@ import sixgaezzang.sidepeek.skill.repository.SkillRepository;
 @RequiredArgsConstructor
 public class SkillService {
 
-    public static final int KEYWORD_MAX_LENGTH = 50;
-
     private final SkillRepository skillRepository;
 
     public SkillSearchResponse searchByName(String keyword) {
@@ -23,8 +22,8 @@ public class SkillService {
             return SkillSearchResponse.from(skillRepository.findAll());
         }
 
-        validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
-                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+        validateMaxLength(keyword, MAX_SKILL_NAME_LENGTH,
+            "최대 " + MAX_SKILL_NAME_LENGTH + "자의 키워드로 검색할 수 있습니다.");
 
         return SkillSearchResponse.from(skillRepository.findAllByNameContaining(keyword));
     }

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
     @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     public ResponseEntity<UserSearchResponse> searchByNickname(
         @RequestParam(required = false)
-        @Size(max = MAX_NICKNAME_LENGTH, message = "최대 20자의 키워드로 검색할 수 있습니다.")
+        @Size(max = MAX_NICKNAME_LENGTH, message = "최대 " + MAX_NICKNAME_LENGTH + "자의 키워드로 검색할 수 있습니다.")
         String keyword
     ) {
         return ResponseEntity.ok()

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.users.domain.Provider;
-import sixgaezzang.sidepeek.users.dto.SignUpRequest;
-import sixgaezzang.sidepeek.users.dto.UserSearchResponse;
+import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
 import sixgaezzang.sidepeek.users.service.UserService;
 
 @RestController

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -49,6 +49,9 @@ public class UserController {
     }
 
     @GetMapping
+    @Operation(summary = "회원 검색")
+    @ApiResponse(responseCode = "200", description = "회원 검색 성공")
+    @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     public ResponseEntity<UserSearchResponse> searchByNickname(
         @RequestParam(required = false)
         @Size(max = 20, message = "최대 20자의 키워드로 검색할 수 있습니다.")

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -1,5 +1,7 @@
 package sixgaezzang.sidepeek.users.controller;
 
+import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -54,7 +56,7 @@ public class UserController {
     @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     public ResponseEntity<UserSearchResponse> searchByNickname(
         @RequestParam(required = false)
-        @Size(max = 20, message = "최대 20자의 키워드로 검색할 수 있습니다.")
+        @Size(max = MAX_NICKNAME_LENGTH, message = "최대 20자의 키워드로 검색할 수 있습니다.")
         String keyword
     ) {
         return ResponseEntity.ok()

--- a/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
@@ -28,7 +28,7 @@ import sixgaezzang.sidepeek.common.domain.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 
-    private static final int MAX_NICKNAME_LENGTH = 20;
+    public static final int MAX_NICKNAME_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.users.dto;
+package sixgaezzang.sidepeek.users.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSearchResponse.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.users.dto;
+package sixgaezzang.sidepeek.users.dto.response;
 
 import java.util.List;
 import sixgaezzang.sidepeek.users.domain.User;

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummaryResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummaryResponse.java
@@ -1,4 +1,4 @@
-package sixgaezzang.sidepeek.users.dto;
+package sixgaezzang.sidepeek.users.dto.response;
 
 import lombok.Builder;
 import sixgaezzang.sidepeek.users.domain.User;

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.users.domain.Password;
 import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.domain.User;
-import sixgaezzang.sidepeek.users.dto.SignUpRequest;
-import sixgaezzang.sidepeek.users.dto.UserSearchResponse;
+import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
 import sixgaezzang.sidepeek.users.repository.UserRepository;
 
 @Service

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -1,6 +1,6 @@
 package sixgaezzang.sidepeek.users.service;
 
-import static sixgaezzang.sidepeek.common.ValidationUtils.validateMaxLength;
+import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
 
 import jakarta.persistence.EntityExistsException;
 import java.util.Objects;

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.users.service;
 
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
+import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
 
 import jakarta.persistence.EntityExistsException;
 import java.util.Objects;
@@ -19,8 +20,6 @@ import sixgaezzang.sidepeek.users.repository.UserRepository;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
-
-    private static final int KEYWORD_MAX_LENGTH = 20;
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -51,8 +50,8 @@ public class UserService {
             return UserSearchResponse.from(userRepository.findAll());
         }
 
-        validateMaxLength(keyword, KEYWORD_MAX_LENGTH,
-                "최대 " + KEYWORD_MAX_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+        validateMaxLength(keyword, MAX_NICKNAME_LENGTH,
+            "최대 " + MAX_NICKNAME_LENGTH + "자의 키워드로 검색할 수 있습니다.");
 
         return UserSearchResponse.from(userRepository.findAllByNicknameContaining(keyword));
     }

--- a/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
@@ -39,8 +39,9 @@ class SkillServiceTest {
 
         @BeforeEach
         void setUp() {
+            String tempImageUrl = "https://google.com/image.png";
             for (int i = 0; i < SKILL_COUNT; i++) {
-                createSkill(skills[i], "url");
+                createSkill(skills[i], tempImageUrl);
             }
         }
 

--- a/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
@@ -40,8 +40,7 @@ class SkillServiceTest {
         @BeforeEach
         void setUp() {
             for (int i = 0; i < SKILL_COUNT; i++) {
-                Skill skill = createSkill(skills[i], "url");
-                skillRepository.save(skill);
+                createSkill(skills[i], "url");
             }
         }
 
@@ -84,10 +83,11 @@ class SkillServiceTest {
     }
 
     private Skill createSkill(String name, String iconImageUrl) {
-        return Skill.builder()
+        Skill skill = Skill.builder()
             .name(name)
             .iconImageUrl(iconImageUrl)
             .build();
+        return skillRepository.save(skill);
     }
 
 }

--- a/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/skill/serivce/SkillServiceTest.java
@@ -1,0 +1,93 @@
+package sixgaezzang.sidepeek.skill.serivce;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
+
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import sixgaezzang.sidepeek.skill.domain.Skill;
+import sixgaezzang.sidepeek.skill.dto.response.SkillResponse;
+import sixgaezzang.sidepeek.skill.repository.SkillRepository;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SkillServiceTest {
+
+    @Autowired
+    SkillService skillService;
+    @Autowired
+    SkillRepository skillRepository;
+
+    @Nested
+    class 기술_스택_검색_테스트 {
+
+        static final int SKILL_COUNT = 5;
+        static final String[] skills = {"spring", "spring boot", "spring web", "react", "react query"};
+
+        @BeforeEach
+        void setUp() {
+            for (int i = 0; i < SKILL_COUNT; i++) {
+                Skill skill = createSkill(skills[i], "url");
+                skillRepository.save(skill);
+            }
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}으로 검색할 때 " + SKILL_COUNT + "개의 모든 기술 스택이 나온다.")
+        @NullAndEmptySource
+        void 검색어_없이_전체_기술_스택_검색에_성공한다(String keyword) {
+            // given, when
+            List<SkillResponse> skills = skillService.searchByName(keyword)
+                .skills();
+
+            // then
+            assertThat(skills.size()).isEqualTo(SKILL_COUNT);
+        }
+
+        @ParameterizedTest(name = "[{index}] {0}으로 검색할 때 {1}개의 기술 스택이 나온다.")
+        @CsvSource(value = {"spring:3", "react:2"}, delimiter = ':')
+        void 검색어로_기술_스택_검색에_성공한다(String keyword, int count) {
+            // given, when
+            List<SkillResponse> skills = skillService.searchByName(keyword)
+                .skills();
+
+            // then
+            assertThat(skills.size()).isEqualTo(count);
+        }
+
+        @Test
+        void 검색어_최대_글자_수가_넘어_기술_스택_검색에_실패한다() {
+            // given
+            int keywordLength = MAX_SKILL_NAME_LENGTH + 1;
+            String keyword = "a".repeat(keywordLength);
+
+            // when
+            ThrowableAssert.ThrowingCallable search = () -> skillService.searchByName(keyword);
+
+            // then
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(search)
+                .withMessage("최대 " + MAX_SKILL_NAME_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+        }
+
+    }
+
+    private Skill createSkill(String name, String iconImageUrl) {
+        return Skill.builder()
+            .name(name)
+            .iconImageUrl(iconImageUrl)
+            .build();
+    }
+
+}

--- a/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.users.domain.Password;
 import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.domain.User;
-import sixgaezzang.sidepeek.users.dto.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
 import sixgaezzang.sidepeek.users.repository.UserRepository;
 
 @SpringBootTest

--- a/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
@@ -154,7 +154,7 @@ class UserServiceTest {
             }
         }
 
-        @ParameterizedTest(name = "[{index}] {0}으로 검색할 때 " + USER_COUNT + "명의 회원이 나온다.")
+        @ParameterizedTest(name = "[{index}] {0}으로 검색할 때 " + USER_COUNT + "명의 모든 회원이 나온다.")
         @NullAndEmptySource
         void 검색어_없이_전체_회원_닉네임_검색에_성공한다(String keyword) {
             // given, when
@@ -177,7 +177,7 @@ class UserServiceTest {
         }
 
         @Test
-        void 닉네임_최대_글자_수가_넘어_회원_닉네임_검색에_실패한다() {
+        void 검색어_최대_글자_수가_넘어_회원_닉네임_검색에_실패한다() {
             // given
             int keywordLength = MAX_NICKNAME_LENGTH + 1;
             String keyword = "a".repeat(keywordLength);


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #51 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 기술 스택 검색 테스트 코드 작성
- [x] 기술 스택 검색 Swagger 정리
- [x] 기술 스택 검색 예외처리 핸들링
- [x] 회원 닉네임 검색 테스트 코드 작성
- [x] 회원 닉네임  검색 Swagger 정리
- [x] 회원 닉네임  검색 예외 처리 핸들링

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 기술 스택 및 회원 닉네임 검색 api 관련해서 마무리로 테스트 코드 작성 및 리팩토링 진행했습니다! 
  - 테스트 코드 작성
  - Swagger 정리하기
  - 예외 처리 핸들링

- 코드,,양이 좀 많아지긴 했네요ㅠㅠㅠ 죄송합니다ㅠㅠ🥲
