### PR TITLE
닉네임 중복 검사 기능 구현

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.users.domain.Provider;
 import sixgaezzang.sidepeek.users.dto.request.CheckEmailRequest;
+import sixgaezzang.sidepeek.users.dto.request.CheckNicknameRequest;
 import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
 import sixgaezzang.sidepeek.users.dto.response.CheckDuplicateResponse;
 import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
@@ -70,6 +71,19 @@ public class UserController {
         @RequestBody @Valid CheckEmailRequest request
     ) {
         CheckDuplicateResponse response = userService.checkEmailDuplicate(request.email());
+
+        return ResponseEntity.ok()
+            .body(response);
+    }
+
+    @PostMapping("/nickname/check")
+    @Operation(summary = "닉네임 중복 확인")
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
+    @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
+    public ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(
+        @RequestBody @Valid CheckNicknameRequest request
+    ) {
+        CheckDuplicateResponse response = userService.checkNicknameDuplicate(request.nickname());
 
         return ResponseEntity.ok()
             .body(response);

--- a/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
@@ -28,7 +28,7 @@ import sixgaezzang.sidepeek.common.domain.BaseTimeEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 
-    private static final int MAX_NICKNAME_LENGTH = 20;
+    public static final int MAX_NICKNAME_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
@@ -1,9 +1,11 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public record CheckEmailRequest(
-    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
@@ -1,11 +1,13 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record CheckNicknameRequest(
     @NotBlank(message = "닉네임을 입력해주세요.")
-    @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+    @Size(max = MAX_NICKNAME_LENGTH, message = "닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하여야 합니다.")
     String nickname
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
@@ -1,0 +1,12 @@
+package sixgaezzang.sidepeek.users.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CheckNicknameRequest(
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+    String nickname
+) {
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
@@ -1,5 +1,7 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -14,7 +16,7 @@ public record SignUpRequest(
     @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
     String password,
     @NotBlank(message = "닉네임을 입력해주세요.")
-    @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+    @Size(max = MAX_NICKNAME_LENGTH, message = "닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하여야 합니다.")
     String nickname
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
@@ -3,7 +3,7 @@ package sixgaezzang.sidepeek.users.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import org.hibernate.validator.constraints.Length;
+import jakarta.validation.constraints.Size;
 import sixgaezzang.sidepeek.users.domain.Password;
 
 public record SignUpRequest(
@@ -14,7 +14,7 @@ public record SignUpRequest(
     @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
     String password,
     @NotBlank(message = "닉네임을 입력해주세요.")
-    @Length(max = 20, message = "닉네임은 20자 이하여야 합니다.")
+    @Size(max = 20, message = "닉네임은 20자 이하여야 합니다.")
     String nickname
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -66,6 +66,14 @@ public class UserService {
         return new CheckDuplicateResponse(isExists);
     }
 
+    public CheckDuplicateResponse checkNicknameDuplicate(String nickname) {
+        validateMaxLength(nickname, User.MAX_NICKNAME_LENGTH,
+            "닉네임은 " + User.MAX_NICKNAME_LENGTH + "자 이하여야 합니다.");
+
+        boolean isExists = userRepository.existsByNickname(nickname);
+        return new CheckDuplicateResponse(isExists);
+    }
+
     private void verifyUniqueNickname(SignUpRequest request) {
         if (userRepository.existsByNickname(request.nickname())) {
             throw new EntityExistsException("이미 사용 중인 닉네임입니다.");

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -59,6 +59,13 @@ public class UserService {
         return UserSearchResponse.from(userRepository.findAllByNicknameContaining(keyword));
     }
 
+    public CheckDuplicateResponse checkEmailDuplicate(String email) {
+        validateEmail(email, "이메일 형식이 올바르지 않습니다.");
+
+        boolean isExists = userRepository.existsByEmail(email);
+        return new CheckDuplicateResponse(isExists);
+    }
+
     private void verifyUniqueNickname(SignUpRequest request) {
         if (userRepository.existsByNickname(request.nickname())) {
             throw new EntityExistsException("이미 사용 중인 닉네임입니다.");
@@ -69,12 +76,5 @@ public class UserService {
         if (userRepository.existsByEmail(request.email())) {
             throw new EntityExistsException("이미 사용 중인 이메일입니다.");
         }
-    }
-
-    public CheckDuplicateResponse checkEmailDuplicate(String email) {
-        validateEmail(email, "이메일 형식이 올바르지 않습니다.");
-
-        boolean isExists = userRepository.existsByEmail(email);
-        return new CheckDuplicateResponse(isExists);
     }
 }

--- a/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
@@ -176,6 +176,50 @@ class UserServiceTest {
         }
     }
 
+    @Nested
+    class 닉네임_중복_확인_테스트 {
+
+        @Test
+        void 닉네임이_중복되지_않은_경우_중복_확인에_성공한다() {
+            // when
+            CheckDuplicateResponse response = userService.checkNicknameDuplicate(nickname);
+
+            // then
+            assertThat(response.isDuplicated()).isFalse();
+        }
+
+        @Test
+        void 닉네임이_중복된_경우_중복_확인에_성공한다() {
+            // given
+            String duplicatedNickname = nickname;
+            User user = createUser(email, password, duplicatedNickname);
+            userRepository.save(user);
+
+            // when
+            CheckDuplicateResponse response = userService.checkNicknameDuplicate(
+                duplicatedNickname);
+
+            // then
+            assertThat(response.isDuplicated()).isTrue();
+        }
+
+        @Test
+        void 닉네임이_최대_길이를_초과하는_경우_중복_확인에_실패한다() {
+            // given
+            String longNickname = faker.lorem()
+                .characters(User.MAX_NICKNAME_LENGTH + 1);
+
+            // when
+            ThrowingCallable checkNicknameDuplicate = () -> userService.checkNicknameDuplicate(
+                longNickname);
+
+            // then
+            assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                    checkNicknameDuplicate)
+                .withMessage("닉네임은 " + User.MAX_NICKNAME_LENGTH + "자 이하여야 합니다.");
+        }
+    }
+
     private User createUser(String email, String password, String nickname) {
         return User.builder()
             .email(isBlank(email) ? this.email : email)


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #54 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 닉네임 중복 확인 서비스 작성
- [x] 닉네임 중복 확인 컨트롤러 작성
- [x] 테스트 코드 작성

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 이메일 중복 검사 기능과 중복되는 부분이 많아서 일단, `feat/#50-check-email-duplicate` 브랜치에서 새로운 브랜치 따서 작업 했습니다! `feat/#50-check-email-duplicate`가 `dev`에 머지되면  `feat/#54-check-nickname-duplicate`도 dev로 머지하겠습니당!
