### PR TITLE
자동 로그인(리프레시 토큰) 기능 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
 
     runs-on: ubuntu-latest
 
+        services:
+            redis:
+                image: redis
+                ports:
+                    - ${{ secrets.TEST_REDIS_PORT }}:6379
+                options: --entrypoint redis-server
+
     steps:
     - name: Repository Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,23 @@
 name: SidePeek CI with Gradle
 
 on:
-   pull_request:
-     branches:
-       - main
-       - dev
-       - 'feat/**'
-       - 'fix/**'
-       - 'refactor/**'
-       - 'chore/**'
+    pull_request:
+        branches:
+            - main
+            - dev
+            - 'feat/**'
+            - 'fix/**'
+            - 'refactor/**'
+            - 'chore/**'
 
 permissions:
-  contents: read
-  checks: write
-  pull-requests: write
+    contents: read
+    checks: write
+    pull-requests: write
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-latest
 
         services:
             redis:
@@ -27,55 +26,55 @@ jobs:
                     - ${{ secrets.TEST_REDIS_PORT }}:6379
                 options: --entrypoint redis-server
 
-    steps:
-    - name: Repository Checkout
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.ACTION_TOKEN }}
-        submodules: true
+        steps:
+            -   name: Repository Checkout
+                uses: actions/checkout@v4
+                with:
+                    token: ${{ secrets.ACTION_TOKEN }}
+                    submodules: true
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'corretto'
+            -   name: Set up JDK 17
+                uses: actions/setup-java@v4
+                with:
+                    java-version: '17'
+                    distribution: 'corretto'
 
-    - name: Set up MySQL
-      uses: samin/mysql-action@v1.3
-      with:
-        mysql user: ${{ secrets.TEST_DB_USER }}
-        mysql password: ${{ secrets.TEST_DB_PASSWORD }}
-        mysql database: ${{ secrets.TEST_DB }}
-        host port: ${{ secrets.TEST_DB_PORT }}
+            -   name: Set up MySQL
+                uses: samin/mysql-action@v1.3
+                with:
+                    mysql user: ${{ secrets.TEST_DB_USER }}
+                    mysql password: ${{ secrets.TEST_DB_PASSWORD }}
+                    mysql database: ${{ secrets.TEST_DB }}
+                    host port: ${{ secrets.TEST_DB_PORT }}
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+            -   name: Grant execute permission for gradlew
+                run: chmod +x gradlew
 
-    - name: Build with Gradle
-      run: ./gradlew build
+            -   name: Build with Gradle
+                run: ./gradlew build
 
-    - name: Test Jacoco Coverage Report
-      id: jacoco
-      uses: madrapps/jacoco-report@v1.6.1
-      with:
-        title: 📝 Jacoco Test Coverage
-        paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
-        min-coverage-overall: 80
-        min-coverage-changed-files: 80
+            -   name: Test Jacoco Coverage Report
+                id: jacoco
+                uses: madrapps/jacoco-report@v1.6.1
+                with:
+                    title: 📝 Jacoco Test Coverage
+                    paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+                    token: ${{ secrets.GITHUB_TOKEN }}
+                    min-coverage-overall: 80
+                    min-coverage-changed-files: 80
 
-    - name: Test Checkstyle Report
-      uses: lcollins/checkstyle-github-action@v2.0.0
-      with:
-        path: '**/build/reports/checkstyle/**.xml'
-        title: 📝 Checkstyle report
+            -   name: Test Checkstyle Report
+                uses: lcollins/checkstyle-github-action@v2.0.0
+                with:
+                    path: '**/build/reports/checkstyle/**.xml'
+                    title: 📝 Checkstyle report
 
-    - name: Send Slack Notification
-      uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        author_name: Github Action Test
-        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      if: always()
+            -   name: Send Slack Notification
+                uses: 8398a7/action-slack@v3
+                with:
+                    status: ${{ job.status }}
+                    author_name: Github Action Test
+                    fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+                env:
+                    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+                if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ Temporary Items
 # Custom ignores
 .env
 .idea/
+
+docker/redis/data/

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -54,7 +55,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-
+    
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,3 +22,21 @@ services:
             TZ: ${TZ}
         ports:
             - "${TEST_DB_PORT}:3306"
+
+    sidepeek-redis:
+        image: redis:latest
+        ports:
+            - ${REDIS_PORT}:6379
+        volumes:
+            - ./redis/data:/data/local
+            - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+        restart: always
+
+    sidepeek-test-redis:
+        image: redis:latest
+        ports:
+            - ${TEST_REDIS_PORT}:6379
+        volumes:
+            - ./redis/data:/data/test
+            - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+        restart: always

--- a/src/main/java/sixgaezzang/sidepeek/auth/domain/RefreshToken.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/domain/RefreshToken.java
@@ -1,0 +1,28 @@
+package sixgaezzang.sidepeek.auth.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@RedisHash("refreshToken")
+@Builder
+public record RefreshToken(
+    @Id
+    Long id,
+    String refreshToken,
+    @TimeToLive
+    Long expiredAt
+) {
+
+    public static final long MILLISECONDS_PER_SECOND = 1000L;
+
+    public static RefreshToken from(Long userId, String refreshToken, Long expiredAt) {
+        return RefreshToken.builder()
+            .id(userId)
+            .refreshToken(refreshToken)
+            .expiredAt(expiredAt / MILLISECONDS_PER_SECOND)
+            .build();
+    }
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/response/LoginResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/response/LoginResponse.java
@@ -6,6 +6,7 @@ import sixgaezzang.sidepeek.users.dto.response.UserSummaryResponse;
 @Builder
 public record LoginResponse(
     String accessToken,
+    String refreshToken,
     UserSummaryResponse user
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
@@ -14,24 +14,29 @@ import sixgaezzang.sidepeek.config.properties.JWTProperties;
 @Component
 public class JWTManager {
 
-    private static final int SECONDS_PER_MINUTE = 60;
-    private static final long MILLISECONDS_PER_SECOND = 1000L;
+    private static final int MINUTE_PER_DAY = 24 * 60;
+    private static final long MILLISECONDS_PER_MINUTE = 60 * 1000L;
     public static final String USER_ID_CLAIM = "user_id";
 
     private final String issuer;
     private final SecretKey secretKey;
     private final long expiredAfter;
+    private final long refreshExpiredAfter;
 
     public JWTManager(JWTProperties jwtProperties) {
-        this.issuer = jwtProperties.issuer();
-        this.secretKey = Keys.hmacShaKeyFor(
-            jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8));
-        this.expiredAfter =
-            jwtProperties.expiredAfter() * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
+        issuer = jwtProperties.issuer();
+        secretKey = Keys.hmacShaKeyFor(jwtProperties.secretKey().getBytes(StandardCharsets.UTF_8));
+        expiredAfter = jwtProperties.expiredAfter() * MILLISECONDS_PER_MINUTE;
+        refreshExpiredAfter =
+            jwtProperties.refreshExpiredAfter() * MINUTE_PER_DAY * MILLISECONDS_PER_MINUTE;
     }
 
     public String generateAccessToken(long userId) {
         return generateToken(userId, expiredAfter);
+    }
+
+    public String generateRefreshToken(long userId) {
+        return generateToken(userId, refreshExpiredAfter);
     }
 
     public Long getUserId(String token) {
@@ -53,5 +58,15 @@ public class JWTManager {
             .claim(USER_ID_CLAIM, userId)
             .signWith(secretKey)
             .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        try {
+            return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            throw new TokenValidationFailException("만료된 토큰입니다.");
+        } catch (Exception e) {
+            throw new TokenValidationFailException("유효하지 않은 토큰입니다.");
+        }
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
@@ -1,11 +1,14 @@
 package sixgaezzang.sidepeek.auth.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
+import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
 import sixgaezzang.sidepeek.config.properties.JWTProperties;
 
 @Component
@@ -28,6 +31,18 @@ public class JWTManager {
     }
 
     public String generateAccessToken(long userId) {
+        return generateToken(userId, expiredAfter);
+    }
+
+    public Long getUserId(String token) {
+        return parseClaims(token).get(USER_ID_CLAIM, Long.class);
+    }
+
+    public Long getExpiredAt(String token) {
+        return parseClaims(token).getExpiration().getTime();
+    }
+
+    private String generateToken(long userId, long expiredAfter) {
         Date now = new Date();
         Date expiredAt = new Date(now.getTime() + expiredAfter);
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package sixgaezzang.sidepeek.auth.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import sixgaezzang.sidepeek.auth.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import sixgaezzang.sidepeek.users.repository.UserRepository;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
     private final PasswordEncoder passwordEncoder;
     private final JWTManager jwtManager;
 
@@ -31,9 +32,12 @@ public class AuthService {
         }
 
         String accessToken = jwtManager.generateAccessToken(user.getId());
+        String refreshToken = jwtManager.generateRefreshToken(user.getId());
+        refreshTokenService.save(refreshToken);
 
         return LoginResponse.builder()
             .accessToken(accessToken)
+            .refreshToken(refreshToken)
             .user(UserSummaryResponse.from(user))
             .build();
     }

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/RefreshTokenService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/RefreshTokenService.java
@@ -1,0 +1,24 @@
+package sixgaezzang.sidepeek.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sixgaezzang.sidepeek.auth.domain.RefreshToken;
+import sixgaezzang.sidepeek.auth.jwt.JWTManager;
+import sixgaezzang.sidepeek.auth.repository.RefreshTokenRepository;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JWTManager jwtManager;
+
+    public RefreshToken save(String token) {
+        Long userId = jwtManager.getUserId(token);
+        Long expirationAt = jwtManager.getExpiredAt(token);
+        RefreshToken refreshToken = RefreshToken.from(userId, token, expirationAt);
+
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -71,6 +71,15 @@ public class GlobalExceptionHandler {
             .body(errorResponse);
     }
 
+    @ExceptionHandler(TokenValidationFailException.class)
+    public ResponseEntity<ErrorResponse> handleTokenValidationFailException(
+        TokenValidationFailException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body(errorResponse);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/TokenValidationFailException.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/TokenValidationFailException.java
@@ -1,0 +1,9 @@
+package sixgaezzang.sidepeek.common.exception;
+
+public class TokenValidationFailException extends RuntimeException {
+
+    public TokenValidationFailException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/config/RedisConfig.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package sixgaezzang.sidepeek.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import sixgaezzang.sidepeek.config.properties.RedisProperties;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
+            redisProperties.host(), redisProperties.port());
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/sixgaezzang/sidepeek/config/SecurityConfig.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import sixgaezzang.sidepeek.auth.jwt.JWTValidationFilter;
-import sixgaezzang.sidepeek.config.properties.JWTProperties;
 
 @Configuration
 @EnableWebSecurity
@@ -22,7 +21,7 @@ import sixgaezzang.sidepeek.config.properties.JWTProperties;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JWTProperties jwtProperties;
+    private final JWTValidationFilter jwtValidationFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -39,9 +38,7 @@ public class SecurityConfig {
             .rememberMe(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
-            .addFilterBefore(new JWTValidationFilter(jwtProperties),
-                BasicAuthenticationFilter.class);
-        ;
+            .addFilterBefore(jwtValidationFilter, BasicAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/sixgaezzang/sidepeek/config/properties/JWTProperties.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/properties/JWTProperties.java
@@ -6,7 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record JWTProperties(
     String issuer,
     String secretKey,
-    int expiredAfter
+    int expiredAfter,
+    int refreshExpiredAfter
 ) {
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/config/properties/RedisProperties.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/properties/RedisProperties.java
@@ -1,0 +1,11 @@
+package sixgaezzang.sidepeek.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.redis")
+public record RedisProperties(
+    String host,
+    int port
+) {
+
+}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -16,14 +16,6 @@ create TABLE IF NOT EXISTS users
     deleted_at        TIMESTAMP          NULL
 );
 
--- AUTHORIZATION
-create TABLE IF NOT EXISTS authorization
-(
-    user_id       BIGINT PRIMARY KEY,
-    refresh_token VARCHAR(255) NULL,
-    FOREIGN KEY (user_id) REFERENCES users (id)
-);
-
 -- AUTH_PROVIDER
 create TABLE IF NOT EXISTS auth_provider
 (

--- a/src/test/java/sixgaezzang/sidepeek/auth/service/AuthServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/auth/service/AuthServiceTest.java
@@ -64,6 +64,7 @@ class AuthServiceTest {
 
             // then
             assertThat(response.accessToken()).isNotNull();
+            assertThat(response.refreshToken()).isNotNull();
             assertThat(response.user()).extracting("id", "nickname", "profileImageUrl")
                 .containsExactly(user.getId(), user.getNickname(), user.getProfileImageUrl());
         }

--- a/src/test/java/sixgaezzang/sidepeek/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,70 @@
+package sixgaezzang.sidepeek.auth.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static sixgaezzang.sidepeek.auth.domain.RefreshToken.MILLISECONDS_PER_SECOND;
+
+import net.datafaker.Faker;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import sixgaezzang.sidepeek.auth.domain.RefreshToken;
+import sixgaezzang.sidepeek.auth.jwt.JWTManager;
+import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
+
+@SpringBootTest
+@Transactional
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class RefreshTokenServiceTest {
+
+    static final Faker faker = new Faker();
+
+    @Autowired
+    RefreshTokenService refreshTokenService;
+
+    @Autowired
+    JWTManager jwtManager;
+
+    String refreshToken;
+
+    @BeforeEach
+    void setUp() {
+        Long userId = faker.random().nextLong(Long.MAX_VALUE);
+        refreshToken = jwtManager.generateRefreshToken(userId);
+    }
+
+    @Nested
+    class 리프레시_토큰_저장_테스트 {
+
+        @Test
+        void 토큰_저장에_성공한다() {
+            // when
+            RefreshToken actual = refreshTokenService.save(refreshToken);
+
+            // then
+            assertThat(actual).isNotNull();
+            assertThat(actual.refreshToken()).isEqualTo(refreshToken);
+            assertThat(actual.expiredAt()).isGreaterThan(
+                System.currentTimeMillis() / MILLISECONDS_PER_SECOND);
+        }
+
+        @Test
+        void 유효하지_않은_토큰인_경우_저장에_실패한다() {
+            // given
+            String invalidToken = faker.animal().name();
+
+            // when
+            ThrowingCallable saven = () -> refreshTokenService.save(invalidToken);
+
+            // then
+            assertThatThrownBy(saven).isInstanceOf(TokenValidationFailException.class)
+                .hasMessage("유효하지 않은 토큰입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Fixes #12 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] redis setup
- [x] Refresh Token 발급 기능 구현
- [x] Refresh Token 발급 및 저장 테스트 코드 작성 

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- Refresh Token을 RDB와 Redis 중 어떤 스토리지에 저장할지 고민한 결과 
  1️⃣ Refresh Token의 접근이 빈번함 (빠른 in-memery 스토리지인 Redis가 적합)
  2️⃣ DB에 영구적으로 보관되는 데이터가 아님
 등의 이유로 **Redis에 저장하기로 결정**했습니다!
- 레디스 관련 `docker-compose.yml` 파일을 수정했기 때문에 `.env` 파일에도 환경 변수 설정이 필요합니다! (구두로 전달드리겠습니당!)

**🙏🏻 sidepeek_backend_secret에 Redis 관련 속성을 추가해서 pull 한번만 부탁 드립니다!**