### PR TITLE
커스텀 에러 코드 적용(User)

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/users/domain/Password.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/domain/Password.java
@@ -2,6 +2,8 @@ package sixgaezzang.sidepeek.users.domain;
 
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateNotBlank;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validatePassword;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.BLANK_PASSWORD;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.INVALID_PASSWORD_FORMAT;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -19,8 +21,8 @@ public class Password {
     private String encoded;
 
     public Password(String password, PasswordEncoder passwordEncoder) {
-        validateNotBlank(password, "비밀번호를 입력해주세요.");
-        validatePassword(password, "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다.");
+        validateNotBlank(password, BLANK_PASSWORD.getMessage());
+        validatePassword(password, INVALID_PASSWORD_FORMAT.getMessage());
         encoded = passwordEncoder.encode(password);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/domain/User.java
@@ -3,6 +3,9 @@ package sixgaezzang.sidepeek.users.domain;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateEmail;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateNotBlank;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.BLANK_NICKNAME;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.EXCESSIVE_NICKNAME_LENGTH;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.INVALID_EMAIL_FORMAT;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -83,12 +86,12 @@ public class User extends BaseTimeEntity {
 
     private void validateConstructorArguments(String nickname, String email) {
         validateNickname(nickname);
-        validateEmail(email, "이메일 형식이 올바르지 않습니다.");
+        validateEmail(email, INVALID_EMAIL_FORMAT.getMessage());
     }
 
     private void validateNickname(String nickname) {
-        validateNotBlank(nickname, "닉네임은 필수값입니다.");
+        validateNotBlank(nickname, BLANK_NICKNAME.getMessage());
         validateMaxLength(nickname, MAX_NICKNAME_LENGTH,
-            "닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하여야 합니다.");
+            EXCESSIVE_NICKNAME_LENGTH.getMessage());
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/exception/UserErrorCode.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/exception/UserErrorCode.java
@@ -1,0 +1,34 @@
+package sixgaezzang.sidepeek.users.exception;
+
+import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
+
+import sixgaezzang.sidepeek.common.exception.ErrorCode;
+
+public enum UserErrorCode implements ErrorCode {
+    DUPLICATE_NICKNAME(1001, "이미 사용 중인 닉네임입니다."),
+    DUPLICATE_EMAIL(1002, "이미 사용 중인 이메일입니다."),
+    INVALID_EMAIL_FORMAT(1003, "유효하지 않은 이메일 형식입니다."),
+    EXCESSIVE_NICKNAME_LENGTH(1004, "닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하여야 합니다."),
+    EXCESSIVE_KEYWORD_LENGTH(1005, "최대 " + MAX_NICKNAME_LENGTH + "자의 키워드로 검색할 수 있습니다."),
+    INVALID_PASSWORD_FORMAT(1006, "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다."),
+    BLANK_PASSWORD(1007, "비밀번호를 입력해주세요."),
+    BLANK_NICKNAME(1008, "닉네임을 입력해주세요.");
+
+    private final int code;
+    private final String message;
+
+    UserErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -3,6 +3,11 @@ package sixgaezzang.sidepeek.users.service;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateEmail;
 import static sixgaezzang.sidepeek.common.util.ValidationUtils.validateMaxLength;
 import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.DUPLICATE_EMAIL;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.DUPLICATE_NICKNAME;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.EXCESSIVE_KEYWORD_LENGTH;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.EXCESSIVE_NICKNAME_LENGTH;
+import static sixgaezzang.sidepeek.users.exception.UserErrorCode.INVALID_EMAIL_FORMAT;
 
 import jakarta.persistence.EntityExistsException;
 import java.util.Objects;
@@ -36,7 +41,7 @@ public class UserService {
             .nickname(request.nickname())
             .password(encodedPassword)
             .build();
-        
+
         userRepository.save(user);
 
         return user.getId();
@@ -47,14 +52,13 @@ public class UserService {
             return UserSearchResponse.from(userRepository.findAll());
         }
 
-        validateMaxLength(keyword, MAX_NICKNAME_LENGTH,
-            "최대 " + MAX_NICKNAME_LENGTH + "자의 키워드로 검색할 수 있습니다.");
+        validateMaxLength(keyword, MAX_NICKNAME_LENGTH, EXCESSIVE_KEYWORD_LENGTH.getMessage());
 
         return UserSearchResponse.from(userRepository.findAllByNicknameContaining(keyword));
     }
 
     public CheckDuplicateResponse checkEmailDuplicate(String email) {
-        validateEmail(email, "이메일 형식이 올바르지 않습니다.");
+        validateEmail(email, INVALID_EMAIL_FORMAT.getMessage());
 
         boolean isExists = userRepository.existsByEmail(email);
         return new CheckDuplicateResponse(isExists);
@@ -62,7 +66,7 @@ public class UserService {
 
     public CheckDuplicateResponse checkNicknameDuplicate(String nickname) {
         validateMaxLength(nickname, User.MAX_NICKNAME_LENGTH,
-            "닉네임은 " + User.MAX_NICKNAME_LENGTH + "자 이하여야 합니다.");
+            EXCESSIVE_NICKNAME_LENGTH.getMessage());
 
         boolean isExists = userRepository.existsByNickname(nickname);
         return new CheckDuplicateResponse(isExists);
@@ -70,13 +74,13 @@ public class UserService {
 
     private void verifyUniqueNickname(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
-            throw new EntityExistsException("이미 사용 중인 닉네임입니다.");
+            throw new EntityExistsException(DUPLICATE_NICKNAME.getMessage());
         }
     }
 
     private void verifyUniqueEmail(String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new EntityExistsException("이미 사용 중인 이메일입니다.");
+            throw new EntityExistsException(DUPLICATE_EMAIL.getMessage());
         }
     }
 }

--- a/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
@@ -121,7 +121,7 @@ class UserServiceTest {
 
             // then
             assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(signup)
-                .withMessage("이메일 형식이 올바르지 않습니다.");
+                .withMessage("유효하지 않은 이메일 형식입니다.");
         }
 
         @Test
@@ -230,7 +230,7 @@ class UserServiceTest {
             // then
             assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
                     checkEmailDuplicate)
-                .withMessage("이메일 형식이 올바르지 않습니다.");
+                .withMessage("유효하지 않은 이메일 형식입니다.");
         }
     }
 


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #74 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] UserErrorCode 생성
- [x] UserErrorCode 적용

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
저희가 커스텀 에러를 사용하지 않는다면, 커스텀 에러 코드(ex. 1001)를 사용할 수 없을 것 같은데 
  1️⃣ 커스텀 에러를 사용한다 
  2️⃣ 에러 코드없이 메시지만 enum으로 관리한다 
같은 방법이 있을 것 같은데, 다음주에 이야기 해보면 좋을 것 같습니당!
