### PR TITLE
프로젝트 저장/수정/삭제 api 스웨거 적용

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -1,24 +1,20 @@
 package sixgaezzang.sidepeek.projects.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import sixgaezzang.sidepeek.common.annotation.Login;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 import sixgaezzang.sidepeek.projects.service.ProjectService;
 
@@ -34,13 +30,7 @@ public class ProjectController {
     @Operation(summary = "프로젝트 생성")
     @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     public ResponseEntity<ProjectResponse> save(
-        @Schema(description = "로그인한 회원 식별자")
-        @Login
-        Long loginId,
-
-        @Valid
-        @RequestBody
-        ProjectRequest request
+        @Valid @RequestBody ProjectSaveRequest request
     ) {
         ProjectResponse response = projectService.save(request);
         URI uri = ServletUriComponentsBuilder.fromCurrentContextPath()
@@ -49,45 +39,6 @@ public class ProjectController {
 
         return ResponseEntity.created(uri)
             .body(response);
-    }
-
-    @PutMapping("/{id}")
-    @Operation(summary = "프로젝트 수정")
-    @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공(프로젝트 작성자/회원 멤버만 가능)")
-    public ResponseEntity<ProjectResponse> update(
-        @Schema(description = "로그인한 회원 식별자")
-        @Login
-        Long loginId,
-
-        @Schema(description = "수정할 프로젝트 식별자")
-        @PathVariable(value = "id")
-        Long projectId,
-
-        @Valid
-        @RequestBody
-        ProjectRequest request
-    ) {
-        ProjectResponse response = projectService.update(loginId, projectId, request);
-
-        return ResponseEntity.ok(response);
-    }
-
-    @DeleteMapping("/{id}")
-    @Operation(summary = "프로젝트 삭제")
-    @ApiResponse(responseCode = "204", description = "프로젝트 삭제 성공(프로젝트 작성자만 가능)")
-    public ResponseEntity<Void> delete(
-        @Schema(description = "로그인한 회원 식별자")
-        @Login
-        Long loginId,
-
-        @Schema(description = "삭제할 프로젝트 식별자")
-        @PathVariable(value = "id")
-        Long projectId
-    ) {
-        projectService.delete(loginId, projectId);
-
-        return ResponseEntity.noContent()
-            .build();
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -27,6 +27,8 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping
+    @Operation(summary = "프로젝트 생성")
+    @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     public ResponseEntity<ProjectResponse> save(
         @Valid @RequestBody ProjectSaveRequest request
     ) {

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -1,20 +1,24 @@
 package sixgaezzang.sidepeek.projects.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
+import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 import sixgaezzang.sidepeek.projects.service.ProjectService;
 
@@ -30,7 +34,13 @@ public class ProjectController {
     @Operation(summary = "프로젝트 생성")
     @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     public ResponseEntity<ProjectResponse> save(
-        @Valid @RequestBody ProjectSaveRequest request
+        @Schema(description = "로그인한 회원 식별자")
+        @Login
+        Long loginId,
+
+        @Valid
+        @RequestBody
+        ProjectRequest request
     ) {
         ProjectResponse response = projectService.save(request);
         URI uri = ServletUriComponentsBuilder.fromCurrentContextPath()
@@ -39,6 +49,45 @@ public class ProjectController {
 
         return ResponseEntity.created(uri)
             .body(response);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "프로젝트 수정")
+    @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공(프로젝트 작성자/회원 멤버만 가능)")
+    public ResponseEntity<ProjectResponse> update(
+        @Schema(description = "로그인한 회원 식별자")
+        @Login
+        Long loginId,
+
+        @Schema(description = "수정할 프로젝트 식별자")
+        @PathVariable(value = "id")
+        Long projectId,
+
+        @Valid
+        @RequestBody
+        ProjectRequest request
+    ) {
+        ProjectResponse response = projectService.update(loginId, projectId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "프로젝트 삭제")
+    @ApiResponse(responseCode = "204", description = "프로젝트 삭제 성공(프로젝트 작성자만 가능)")
+    public ResponseEntity<Void> delete(
+        @Schema(description = "로그인한 회원 식별자")
+        @Login
+        Long loginId,
+
+        @Schema(description = "삭제할 프로젝트 식별자")
+        @PathVariable(value = "id")
+        Long projectId
+    ) {
+        projectService.delete(loginId, projectId);
+
+        return ResponseEntity.noContent()
+            .build();
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
@@ -1,23 +1,28 @@
 package sixgaezzang.sidepeek.projects.dto.request;
 
 import static sixgaezzang.sidepeek.common.util.CommonConstant.MIN_ID;
+import static sixgaezzang.sidepeek.projects.exception.message.MemberErrorMessage.NON_FELLOW_MEMBER_NICKNAME_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.projects.exception.message.MemberErrorMessage.ROLE_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_ROLE_LENGTH;
 import static sixgaezzang.sidepeek.users.domain.User.MAX_NICKNAME_LENGTH;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "프로젝트 생성 요청에서 프로젝트 멤버 정보")
 public record MemberSaveRequest(
+    @Schema(description = "회원 멤버 유저 Id(비회원 멤버이면 null)", example = "1")
     @Min(value = MIN_ID, message = "멤버 회원 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     Long userId,
 
-    @Size(max = MAX_NICKNAME_LENGTH,
-        message = "멤버 닉네임은 " + MAX_NICKNAME_LENGTH + "자를 넘을 수 없습니다.")
+    @Schema(description = "비회원 멤버 닉네임(회원 멤버이면 null)", example = " ")
+    @Size(max = MAX_NICKNAME_LENGTH, message = NON_FELLOW_MEMBER_NICKNAME_OVER_MAX_LENGTH)
     String nickname,
 
-    @Size(max = MAX_ROLE_LENGTH,
-        message = "멤버 역할은 " + MAX_ROLE_LENGTH + "자를 넘을 수 없습니다.")
+    @Schema(description = "멤버 역할", example = "백엔드")
+    @Size(max = MAX_ROLE_LENGTH, message = ROLE_OVER_MAX_LENGTH)
     @NotBlank(message = "멤버 역할을 입력해주세요.")
     String role
 ) {

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import org.hibernate.validator.constraints.URL;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
-@Schema(description = "프로젝트 생성 요청 정보")
+@Schema(description = "프로젝트 생성/수정 요청 정보")
 public record ProjectRequest(
     // Required
     @Schema(description = "프로젝트 제목", example = "사이드픽👀")

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
@@ -31,7 +31,7 @@ import org.hibernate.validator.constraints.URL;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
 @Schema(description = "프로젝트 생성 요청 정보")
-public record ProjectSaveRequest(
+public record ProjectRequest(
     // Required
     @Schema(description = "프로젝트 제목", example = "사이드픽👀")
     @Size(max = MAX_PROJECT_NAME_LENGTH, message = NAME_OVER_MAX_LENGTH)

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import org.hibernate.validator.constraints.URL;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
-@Schema(description = "프로젝트 생성/수정 요청 정보")
+@Schema(description = "프로젝트 생성 요청 정보")
 public record ProjectRequest(
     // Required
     @Schema(description = "프로젝트 제목", example = "사이드픽👀")

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSaveRequest.java
@@ -43,7 +43,7 @@ public record ProjectSaveRequest(
     @NotBlank(message = OVERVIEW_IS_NULL)
     String overview,
 
-    @Schema(description = "프로젝트 작성자 Id", example = "1")
+    @Schema(description = "프로젝트 작성자 Id(회원 식별자)", example = "1")
     @Min(value = MIN_ID, message = "작성자 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     @NotNull(message = OWNER_ID_IS_NULL)
     Long ownerId,
@@ -85,8 +85,7 @@ public record ProjectSaveRequest(
     @Schema(description = "프로젝트 트러블 슈팅", example = "## 사이드픽 트러블 슈팅 Markdown")
     String troubleShooting,
 
-    @Schema(description = "프로젝트 레이아웃 이미지 URL 목록",
-        example = "[\"https://sidepeek.image/img1.jpg\", \"https://sidepeek.image/img2.jpg\"]")
+    @Schema(description = "프로젝트 레이아웃 이미지 URL 목록", example = "[\"https://sidepeek.image/img1.jpg\"]")
     List<String> overviewImageUrls,
 
     @Schema(description = "프로젝트 레이아웃 멤버 목록")

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSaveRequest.java
@@ -2,11 +2,24 @@ package sixgaezzang.sidepeek.projects.dto.request;
 
 import static sixgaezzang.sidepeek.common.util.CommonConstant.MIN_ID;
 import static sixgaezzang.sidepeek.common.util.Regex.URL_REGEXP;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.DEPLOY_URL_IS_INVALID;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.DESCRIPTION_IS_NULL;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.GITHUB_URL_IS_INVALID;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.GITHUB_URL_IS_NULL;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.NAME_IS_NULL;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.NAME_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.OVERVIEW_IS_NULL;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.OVERVIEW_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.OWNER_ID_IS_NULL;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.SUB_NAME_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessage.THUMBNAIL_URL_IS_INVALID;
+import static sixgaezzang.sidepeek.projects.exception.message.ProjectSkillErrorMessage.PROJECT_TECH_STACKS_IS_NULL;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_OVERVIEW_LENGTH;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_PROJECT_NAME_LENGTH;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.YEAR_MONTH_PATTERN;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -14,57 +27,69 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.YearMonth;
 import java.util.List;
-import lombok.Builder;
 import org.hibernate.validator.constraints.URL;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
+@Schema(description = "프로젝트 생성 요청 정보")
 public record ProjectSaveRequest(
     // Required
-    @Size(max = MAX_PROJECT_NAME_LENGTH,
-        message = "프로젝트 제목은 " + MAX_PROJECT_NAME_LENGTH + "자를 넘을 수 없습니다.")
-    @NotBlank(message = "프로젝트 제목을 입력해주세요.")
+    @Schema(description = "프로젝트 제목", example = "사이드픽👀")
+    @Size(max = MAX_PROJECT_NAME_LENGTH, message = NAME_OVER_MAX_LENGTH)
+    @NotBlank(message = NAME_IS_NULL)
     String name,
 
-    @Size(max = MAX_OVERVIEW_LENGTH,
-        message = "프로젝트 개요는 " + MAX_OVERVIEW_LENGTH + "자를 넘을 수 없습니다.")
-    @NotBlank(message = "프로젝트 개요를 입력해주세요.")
+    @Schema(description = "프로젝트 개요", example = "사이드 프로젝트를 공유하는 사이드픽입니다.")
+    @Size(max = MAX_OVERVIEW_LENGTH, message = OVERVIEW_OVER_MAX_LENGTH)
+    @NotBlank(message = OVERVIEW_IS_NULL)
     String overview,
 
+    @Schema(description = "프로젝트 작성자 Id", example = "1")
     @Min(value = MIN_ID, message = "작성자 id는 " + MIN_ID + "보다 작을 수 없습니다.")
-    @NotNull(message = "프로젝트 작성자 Id를 함께 보내주세요.")
+    @NotNull(message = OWNER_ID_IS_NULL)
     Long ownerId,
 
-    @URL(message = "올바른 url 형식이 아닙니다.", regexp = URL_REGEXP)
-    @NotBlank(message = "프로젝트 깃허브 url을 입력해주세요.")
+    @Schema(description = "프로젝트 Github URL", example = "https://github.com/side-peek")
+    @URL(message = GITHUB_URL_IS_INVALID, regexp = URL_REGEXP)
+    @NotBlank(message = GITHUB_URL_IS_NULL)
     String githubUrl,
 
-    @NotBlank(message = "프로젝트 기능 설명을 작성해주세요.")
+    @Schema(description = "프로젝트 기능 설명", example = "## 사이드픽 기능 설명 Markdown")
+    @NotBlank(message = DESCRIPTION_IS_NULL)
     String description,
 
-    @NotEmpty(message = "프로젝트에서 사용한 기술 스택을 등록해주세요.")
+    @Schema(description = "프로젝트 기술 스택")
+    @NotEmpty(message = PROJECT_TECH_STACKS_IS_NULL)
     List<ProjectSkillSaveRequest> techStacks,
 
     // Option
-    @Size(max = MAX_PROJECT_NAME_LENGTH,
-        message = "프로젝트 부제목은 " + MAX_PROJECT_NAME_LENGTH + "자를 넘을 수 없습니다.")
+    @Schema(description = "프로젝트 부제목", example = "좋은 아이디어? 사이드픽에서 찾아봐!")
+    @Size(max = MAX_PROJECT_NAME_LENGTH, message = SUB_NAME_OVER_MAX_LENGTH)
     String subName,
 
-    @URL(message = "올바른 url 형식이 아닙니다.", regexp = URL_REGEXP)
+    @Schema(description = "프로젝트 썸네일 이미지 URL", example = "https://sidepeek.image/imageeUrl")
+    @URL(message = THUMBNAIL_URL_IS_INVALID, regexp = URL_REGEXP)
     String thumbnailUrl,
 
-    @URL(message = "올바른 url 형식이 아닙니다.", regexp = URL_REGEXP)
+    @Schema(description = "프로젝트 배포 URL", example = "https://www.sidepeek.com")
+    @URL(message = DEPLOY_URL_IS_INVALID, regexp = URL_REGEXP)
     String deployUrl,
 
+    @Schema(description = "프로젝트 시작 연-월", example = "2024-02")
     @JsonFormat(pattern = YEAR_MONTH_PATTERN)
     YearMonth startDate,
 
+    @Schema(description = "프로젝트 종료 연-월", example = "2024-03")
     @JsonFormat(pattern = YEAR_MONTH_PATTERN)
     YearMonth endDate,
 
+    @Schema(description = "프로젝트 트러블 슈팅", example = "## 사이드픽 트러블 슈팅 Markdown")
     String troubleShooting,
 
+    @Schema(description = "프로젝트 레이아웃 이미지 URL 목록",
+        example = "[\"https://sidepeek.image/img1.jpg\", \"https://sidepeek.image/img2.jpg\"]")
     List<String> overviewImageUrls,
 
+    @Schema(description = "프로젝트 레이아웃 멤버 목록")
     List<MemberSaveRequest> members
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSkillSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSkillSaveRequest.java
@@ -2,20 +2,26 @@ package sixgaezzang.sidepeek.projects.dto.request;
 
 import static sixgaezzang.sidepeek.common.util.CommonConstant.MIN_ID;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_CATEGORY_LENGTH;
+import static sixgaezzang.sidepeek.skill.util.validation.SkillErrorMessage.CATEGORY_IS_NULL;
+import static sixgaezzang.sidepeek.skill.util.validation.SkillErrorMessage.CATEGORY_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.skill.util.validation.SkillErrorMessage.SKILL_ID_IS_NULL;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "프로젝트 생성 요청에서 프로젝트 기술 스택 정보")
 public record ProjectSkillSaveRequest(
+    @Schema(description = "기술 스택 Id", example = "1")
     @Min(value = MIN_ID, message = "스킬 id는 " + MIN_ID + "보다 작을 수 없습니다.")
-    @NotNull(message = "스킬 id를 입력해주세요.")
+    @NotNull(message = SKILL_ID_IS_NULL)
     Long skillId,
 
-    @Size(max = MAX_CATEGORY_LENGTH,
-        message = "스킬 카테고리는 " + MAX_CATEGORY_LENGTH + "자를 넘을 수 없습니다.")
-    @NotBlank(message = "스킬 카테고리를 입력해주세요.")
+    @Schema(description = "기술 스택 카테고리", example = "프론트엔드")
+    @Size(max = MAX_CATEGORY_LENGTH, message = CATEGORY_OVER_MAX_LENGTH)
+    @NotBlank(message = CATEGORY_IS_NULL)
     String category
 ) {
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/MemberSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/MemberSummary.java
@@ -1,14 +1,19 @@
 package sixgaezzang.sidepeek.projects.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.projects.domain.member.Member;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
+@Schema(description = "프로젝트 멤버 정보")
 @Builder
 public record MemberSummary(
+    @Schema(description = "프로젝트 멤버 식별자", example = "1")
     Long id,
+    @Schema(description = "프로젝트 멤버 역할", example = "백엔드")
     String role,
+    @Schema(description = "프로젝트 멤버 회원/비회원 상세정보")
     UserSummary userSummary
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/OverviewImageSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/OverviewImageSummary.java
@@ -1,11 +1,15 @@
 package sixgaezzang.sidepeek.projects.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.projects.domain.file.File;
 
+@Schema(description = "프로젝트 레이아웃 이미지 URL 정보")
 @Builder
 public record OverviewImageSummary(
+    @Schema(description = "프로젝트 레이아웃 이미지 URL 식별자", example = "1")
     Long id,
+    @Schema(description = "프로젝트 레이아웃 이미지 URL", example = "https://sidepeek.image/img1.jpg")
     String url
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
@@ -1,28 +1,47 @@
 package sixgaezzang.sidepeek.projects.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.Builder;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
+@Schema(description = "프로젝트 상세조회 응답")
 @Builder
 public record ProjectResponse(
+    @Schema(description = "프로젝트 식별자", example = "1")
     Long id,
+    @Schema(description = "프로젝트 제목", example = "사이드픽👀")
     String name,
+    @Schema(description = "프로젝트 부제목", example = "좋은 아이디어? 사이드픽에서 찾아봐!")
     String subName,
+    @Schema(description = "프로젝트 개요", example = "사이드 프로젝트를 공유하는 사이드픽입니다.")
     String overview,
+    @Schema(description = "프로젝트 썸네일 이미지 URL", example = "https://sidepeek.image/imageeUrl")
     String thumbnailUrl,
+    @Schema(description = "프로젝트 레이아웃 이미지 URL 목록")
     List<OverviewImageSummary> overviewImageUrl,
+    @Schema(description = "프로젝트 Github URL", example = "https://github.com/side-peek")
     String githubUrl,
+    @Schema(description = "프로젝트 배포 URL", example = "https://www.sidepeek.com")
     String deployUrl,
+    @Schema(description = "프로젝트 조회수", example = "1")
     Long viewCount,
+    @Schema(description = "프로젝트 좋아요수", example = "0")
     Long likeCount,
+    @Schema(description = "프로젝트 기술 스택 목록")
     List<ProjectSkillSummary> techStacks,
+    @Schema(description = "프로젝트 시작 연-월", example = "2024-02")
     YearMonth startDate,
+    @Schema(description = "프로젝트 종료 연-월", example = "2024-03")
     YearMonth endDate,
+    @Schema(description = "프로젝트 작성자 Id", example = "1")
     Long ownerId,
+    @Schema(description = "프로젝트 멤버 목록")
     List<MemberSummary> members,
+    @Schema(description = "프로젝트 기능 설명", example = "## 사이드픽 기능 설명 Markdown")
     String description,
+    @Schema(description = "프로젝트 트러블 슈팅", example = "## 사이드픽 트러블 슈팅 Markdown")
     String troubleShooting
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectSkillSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectSkillSummary.java
@@ -1,13 +1,18 @@
 package sixgaezzang.sidepeek.projects.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.projects.domain.ProjectSkill;
 import sixgaezzang.sidepeek.skill.dto.response.SkillResponse;
 
+@Schema(description = "프로젝트 기술 스택 정보")
 @Builder
 public record ProjectSkillSummary(
+    @Schema(description = "프로젝트 기술 스택 식별자", example = "1")
     Long id,
+    @Schema(description = "프로젝트 기술 스택 카테고리", example = "프론트엔드")
     String category,
+    @Schema(description = "프로젝트 기술 스택 상세정보")
     SkillResponse skill
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.file.FileType;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.MemberSummary;
 import sixgaezzang.sidepeek.projects.dto.response.OverviewImageSummary;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
@@ -26,19 +26,19 @@ public class ProjectService {
     private final FileService fileService;
 
     @Transactional
-    public ProjectResponse save(ProjectSaveRequest projectSaveRequest) {
-        // TODO: accessToken에서 userId 꺼내서 ownerId와 비교!!
+    public ProjectResponse save(ProjectRequest request) {
+        // TODO: loginId, ownerId와 비교!
 
-        Project project = projectSaveRequest.toEntity();
+        Project project = request.toEntity();
         projectRepository.save(project);
 
         // Required
-        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project, projectSaveRequest.techStacks());
+        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project, request.techStacks());
 
         // Option
-        List<MemberSummary> members = memberService.saveAll(project, projectSaveRequest.members());
+        List<MemberSummary> members = memberService.saveAll(project, request.members());
         List<OverviewImageSummary> overviewImages =
-            fileService.saveAll(project, projectSaveRequest.overviewImageUrls());
+            fileService.saveAll(project, request.overviewImageUrls());
 
         return ProjectResponse.from(project, overviewImages, techStacks, members);
     }
@@ -68,4 +68,14 @@ public class ProjectService {
         return ProjectResponse.from(project, overviewImages, techStacks, members);
     }
 
+    @Transactional
+    public ProjectResponse update(Long loginId, Long projectId, ProjectRequest request) {
+        // TODO: 작성자와 멤버만이 수정할 수 있다.
+        return null;
+    }
+
+    @Transactional
+    public void delete(Long loginId, Long projectId) {
+        // TODO: 작성자만이 삭제할 수 있다.
+    }
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.file.FileType;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
 import sixgaezzang.sidepeek.projects.dto.response.MemberSummary;
 import sixgaezzang.sidepeek.projects.dto.response.OverviewImageSummary;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
@@ -26,19 +26,19 @@ public class ProjectService {
     private final FileService fileService;
 
     @Transactional
-    public ProjectResponse save(ProjectRequest request) {
-        // TODO: loginId, ownerId와 비교!
+    public ProjectResponse save(ProjectSaveRequest projectSaveRequest) {
+        // TODO: accessToken에서 userId 꺼내서 ownerId와 비교!!
 
-        Project project = request.toEntity();
+        Project project = projectSaveRequest.toEntity();
         projectRepository.save(project);
 
         // Required
-        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project, request.techStacks());
+        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project, projectSaveRequest.techStacks());
 
         // Option
-        List<MemberSummary> members = memberService.saveAll(project, request.members());
+        List<MemberSummary> members = memberService.saveAll(project, projectSaveRequest.members());
         List<OverviewImageSummary> overviewImages =
-            fileService.saveAll(project, request.overviewImageUrls());
+            fileService.saveAll(project, projectSaveRequest.overviewImageUrls());
 
         return ProjectResponse.from(project, overviewImages, techStacks, members);
     }
@@ -68,14 +68,4 @@ public class ProjectService {
         return ProjectResponse.from(project, overviewImages, techStacks, members);
     }
 
-    @Transactional
-    public ProjectResponse update(Long loginId, Long projectId, ProjectRequest request) {
-        // TODO: 작성자와 멤버만이 수정할 수 있다.
-        return null;
-    }
-
-    @Transactional
-    public void delete(Long loginId, Long projectId) {
-        // TODO: 작성자만이 삭제할 수 있다.
-    }
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillResponse.java
@@ -1,12 +1,17 @@
 package sixgaezzang.sidepeek.skill.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.skill.domain.Skill;
 
+@Schema(description = "기술 스택 정보")
 @Builder
 public record SkillResponse(
+    @Schema(description = "기술 스택 식별자", example = "1")
     Long id,
+    @Schema(description = "기술 스택 이름", example = "React")
     String name,
+    @Schema(description = "기술 스택 아이콘 이미지 URL", example = "https://sidepeek.image/icon1.jpg")
     String iconImageUrl
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -1,12 +1,17 @@
 package sixgaezzang.sidepeek.users.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.users.domain.User;
 
+@Schema(description = "회원 상세정보")
 @Builder
 public record UserSummary(
+    @Schema(description = "회원 식별자(비회원은 null)", example = "1")
     Long id,
+    @Schema(description = "회원/비회원 닉네임", example = "의진")
     String nickname,
+    @Schema(description = "회원 프로필 이미지(비회원은 null)", example = "https://user-images.githubusercontent.com/uijin.png")
     String profileImageUrl
 ) {
 

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
@@ -23,7 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.dto.request.MemberSaveRequest;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.request.ProjectSkillSaveRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 import sixgaezzang.sidepeek.projects.exception.ProjectErrorCode;
@@ -141,7 +141,7 @@ class ProjectServiceTest {
         @Test
         void 필수_정보가_모두_포함되어_프로젝트_저장에_성공한다() {
             // given
-            ProjectSaveRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
+            ProjectRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
                 NAME, OVERVIEW, GITHUB_URL, DESCRIPTION, user.getId(), techStacks
             );
 
@@ -160,7 +160,7 @@ class ProjectServiceTest {
             String testMessage, String name, String overview, String githubUrl, String description, String message
         ) {
             // given
-            ProjectSaveRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
+            ProjectRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
                 name, overview, githubUrl, description, user.getId(), techStacks
             );
 
@@ -175,7 +175,7 @@ class ProjectServiceTest {
         @Test
         void 작성자_Id가_누락되어_프로젝트_저장에_실패한다() {
             // given
-            ProjectSaveRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
+            ProjectRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
                 NAME, OVERVIEW, GITHUB_URL, DESCRIPTION, null, techStacks
             );
 
@@ -193,7 +193,7 @@ class ProjectServiceTest {
             String testMessage, String name, String overview, String githubUrl, String description, String message
         ) {
             // given
-            ProjectSaveRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
+            ProjectRequest request = FakeDtoProvider.createProjectSaveRequestOnlyRequired(
                 name, overview, githubUrl, description, user.getId(), techStacks
             );
 
@@ -212,7 +212,7 @@ class ProjectServiceTest {
             YearMonth startDate, YearMonth endDate, String message
         ) {
             // given
-            ProjectSaveRequest request = FakeDtoProvider.createProjectSaveRequestWithOwnerIdAndOption(
+            ProjectRequest request = FakeDtoProvider.createProjectSaveRequestWithOwnerIdAndOption(
                 techStacks, user.getId(), subName, thumbnailUrl, deployUrl, troubleShooting, startDate, endDate
             );
 

--- a/src/test/java/sixgaezzang/sidepeek/projects/util/FakeDtoProvider.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/util/FakeDtoProvider.java
@@ -6,7 +6,7 @@ import static sixgaezzang.sidepeek.projects.util.FakeValueProvider.createRole;
 import java.time.YearMonth;
 import java.util.List;
 import sixgaezzang.sidepeek.projects.dto.request.MemberSaveRequest;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectSaveRequest;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.request.ProjectSkillSaveRequest;
 
 public class FakeDtoProvider {
@@ -17,20 +17,20 @@ public class FakeDtoProvider {
     }
 
     // Project
-    public static ProjectSaveRequest createProjectSaveRequestOnlyRequired(
+    public static ProjectRequest createProjectSaveRequestOnlyRequired(
         String name, String overview, String githubUrl, String description, Long ownerId,
         List<ProjectSkillSaveRequest> techStacks
     ) {
-        return new ProjectSaveRequest(name, overview, ownerId, githubUrl, description,
+        return new ProjectRequest(name, overview, ownerId, githubUrl, description,
             techStacks, null, null, null, null,
             null, null, null, null);
     }
 
-    public static ProjectSaveRequest createProjectSaveRequestWithOwnerIdAndOption(
+    public static ProjectRequest createProjectSaveRequestWithOwnerIdAndOption(
         List<ProjectSkillSaveRequest> techStacks, Long ownerId, String subName, String thumbnailUrl, String deployUrl,
         String troubleShooting, YearMonth startDate, YearMonth endDate
     ) {
-        return new ProjectSaveRequest(
+        return new ProjectRequest(
             FakeValueProvider.createProjectName(), FakeValueProvider.createOverview(), ownerId,
             FakeValueProvider.createUrl(), FakeValueProvider.createLongText(), techStacks, subName,
             thumbnailUrl, deployUrl, startDate, endDate, troubleShooting, null, null


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #77 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 프로젝트 저장 api 스웨거 적용
  - [x] api 성공 예시 작성 
  - [x] 요청 dto
  - [x] 응답 dto : 프로젝트 상세 조회와 응답이 비슷해서 함께 적용되었습니다!
- [x] 프로젝트 수정/삭제 api 컨트롤러 구현+스웨거 적용했습니다! (기능 구현X)
  - 브랜치를 나눠야 했는데 확인을 못하고 푸시 했습니다,,, 양이 많지는 않아서 함께 올립니다!  

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 스웨거에 예시 값 적용해놓았습니당!
- 요청 예시 적용

<img width="1037" alt="image" src="https://github.com/side-peek/sidepeek_backend/assets/85275893/c9e07092-78d8-47ba-b3e2-8d36bc2670f3">

- 성공 응답 예시 적용 

<img width="988" alt="image" src="https://github.com/side-peek/sidepeek_backend/assets/85275893/3ee80996-c405-4d26-b9c2-9470bf085066">
