### PR TITLE
스웨거 리팩토링

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -331,4 +331,9 @@
         <property name="message" value="연속적인 공백 라인은 1줄을 넘을 수 없습니다."/>
         <property name="severity" value="error"/>
     </module>
+
+    <!-- Checkstyle 예외 설정 -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml"/>
+    </module>
 </module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+    <!-- DTO 패키지 하위의 Java 파일에 대한 LineLength 검사를 무시 -->
+    <suppress checks="LineLength"
+        files="[/\\]dto[/\\]"/>
+
+    <!-- DOC 패키지 하위에 대한 LineLength 검사를 무시 -->
+    <suppress checks="LineLength"
+        files="[\\/]common[\\/]doc[\\/]"/>
+</suppressions>

--- a/src/main/java/sixgaezzang/sidepeek/auth/controller/AuthController.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/controller/AuthController.java
@@ -1,9 +1,5 @@
 package sixgaezzang.sidepeek.auth.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,40 +12,34 @@ import sixgaezzang.sidepeek.auth.dto.request.ReissueTokenRequest;
 import sixgaezzang.sidepeek.auth.dto.response.LoginResponse;
 import sixgaezzang.sidepeek.auth.service.AuthService;
 import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.common.doc.AuthControllerDoc;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDoc {
 
     private final AuthService authService;
 
+    @Override
     @PostMapping("/login")
-    @Operation(summary = "로그인")
-    @ApiResponse(responseCode = "200", description = "로그인 성공")
-    @Parameters({
-        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
-        @Parameter(name = "password", description = "비밀번호", example = "sidepeek6!")
-    })
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         LoginResponse response = authService.login(request);
 
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @PostMapping("/me")
-    @Operation(summary = "Access Token 검증")
-    @ApiResponse(responseCode = "200", description = "Access Token 검증 성공")
     public ResponseEntity<UserSummary> validateToken(@Login Long loginId) {
         UserSummary response = authService.loadUser(loginId);
 
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @PostMapping("/reissue")
-    @Operation(summary = "Access / Refresh Token 재발급")
-    @ApiResponse(responseCode = "200", description = "Access / Refresh Token 재발급 성공")
     public ResponseEntity<LoginResponse> reissue(@RequestBody @Valid ReissueTokenRequest request) {
         LoginResponse response = authService.reissue(request);
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/request/LoginRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/request/LoginRequest.java
@@ -1,15 +1,18 @@
 package sixgaezzang.sidepeek.auth.dto.request;
 
+import static sixgaezzang.sidepeek.auth.exeption.message.AuthErrorMessage.EMAIL_IS_NULL;
+import static sixgaezzang.sidepeek.auth.exeption.message.AuthErrorMessage.PASSWORD_IS_NULL;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "로그인 요청")
 public record LoginRequest(
     @Schema(description = "이메일", example = "sidepeek@gmail.com")
-    @NotBlank(message = "이메일을 입력해 주세요.")
+    @NotBlank(message = EMAIL_IS_NULL)
     String email,
     @Schema(description = "비밀번호", example = "sidepeek6!")
-    @NotBlank(message = "비밀번호를 입력해 주세요.")
+    @NotBlank(message = PASSWORD_IS_NULL)
     String password
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/request/LoginRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/request/LoginRequest.java
@@ -1,10 +1,14 @@
 package sixgaezzang.sidepeek.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "로그인 요청")
 public record LoginRequest(
+    @Schema(description = "이메일", example = "sidepeek@gmail.com")
     @NotBlank(message = "이메일을 입력해 주세요.")
     String email,
+    @Schema(description = "비밀번호", example = "sidepeek6!")
     @NotBlank(message = "비밀번호를 입력해 주세요.")
     String password
 ) {

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/request/ReissueTokenRequest.java
@@ -1,8 +1,11 @@
 package sixgaezzang.sidepeek.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "토큰 재발급 요청")
 public record ReissueTokenRequest(
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA5Mzg0NTU5LCJ1c2VyX2lkIjozfQ.lDZaPmXFWfN6z4p6pWdNMA8coTxGNJjadC_X1liEMsZRkote7NaD4cemZnU5ag3tgH5y0SOeXTJkBO11aENVnw")
     @NotBlank(message = "Refresh Token은 필수값입니다.")
     String refreshToken
 ) {

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/request/ReissueTokenRequest.java
@@ -1,12 +1,14 @@
 package sixgaezzang.sidepeek.auth.dto.request;
 
+import static sixgaezzang.sidepeek.auth.exeption.message.AuthErrorMessage.REFRESH_TOKEN_IS_NULL;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "토큰 재발급 요청")
 public record ReissueTokenRequest(
     @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA5Mzg0NTU5LCJ1c2VyX2lkIjozfQ.lDZaPmXFWfN6z4p6pWdNMA8coTxGNJjadC_X1liEMsZRkote7NaD4cemZnU5ag3tgH5y0SOeXTJkBO11aENVnw")
-    @NotBlank(message = "Refresh Token은 필수값입니다.")
+    @NotBlank(message = REFRESH_TOKEN_IS_NULL)
     String refreshToken
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/response/LoginResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/response/LoginResponse.java
@@ -1,12 +1,17 @@
 package sixgaezzang.sidepeek.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
+@Schema(description = "로그인 응답")
 @Builder
 public record LoginResponse(
+    @Schema(description = "Access 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA4NzgzMzU5LCJ1c2VyX2lkIjozfQ.KA5BjtJtyYA-SEHKn_E4hTwz6YhZ2rMXsnIflL5zoa_GjBi4KTRiYbveBhUBKq1q4Qfb1HgRg-vy4G9YIg9MVQ")
     String accessToken,
+    @Schema(description = "Refresh 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA5Mzg0NTU5LCJ1c2VyX2lkIjozfQ.lDZaPmXFWfN6z4p6pWdNMA8coTxGNJjadC_X1liEMsZRkote7NaD4cemZnU5ag3tgH5y0SOeXTJkBO11aENVnw")
     String refreshToken,
+    @Schema(description = "로그인 사용자 정보")
     UserSummary user
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/dto/response/SocialLoginResponse.java
@@ -1,16 +1,23 @@
 package sixgaezzang.sidepeek.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.auth.domain.AuthProvider;
 import sixgaezzang.sidepeek.auth.domain.ProviderType;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
+@Schema(description = "소셜 로그인 응답")
 @Builder
 public record SocialLoginResponse(
+    @Schema(description = "Access 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA4NzgzMzU5LCJ1c2VyX2lkIjozfQ.KA5BjtJtyYA-SEHKn_E4hTwz6YhZ2rMXsnIflL5zoa_GjBi4KTRiYbveBhUBKq1q4Qfb1HgRg-vy4G9YIg9MVQ")
     String accessToken,
+    @Schema(description = "Refresh 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJzaXhnYWV6emFuZyIsImlhdCI6MTcwODc3OTc1OSwiZXhwIjoxNzA5Mzg0NTU5LCJ1c2VyX2lkIjozfQ.lDZaPmXFWfN6z4p6pWdNMA8coTxGNJjadC_X1liEMsZRkote7NaD4cemZnU5ag3tgH5y0SOeXTJkBO11aENVnw")
     String refreshToken,
+    @Schema(description = "소셜 로그인 타입", example = "GITHUB")
     ProviderType providerType,
+    @Schema(description = "회원가입 완료 여부", example = "true")
     boolean isRegistrationComplete,
+    @Schema(description = "로그인 사용자 정보")
     UserSummary user
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/exeption/message/AuthErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/exeption/message/AuthErrorMessage.java
@@ -1,0 +1,12 @@
+package sixgaezzang.sidepeek.auth.exeption.message;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthErrorMessage {
+
+    public static final String EMAIL_IS_NULL = "이메일을 입력해주세요.";
+    public static final String PASSWORD_IS_NULL = "비밀번호를 입력해주세요.";
+    public static final String REFRESH_TOKEN_IS_NULL = "Refresh Token을 입력해주세요.";
+}

--- a/src/main/java/sixgaezzang/sidepeek/comments/controller/CommentController.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/controller/CommentController.java
@@ -1,9 +1,5 @@
 package sixgaezzang.sidepeek.comments.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,70 +13,40 @@ import org.springframework.web.bind.annotation.RestController;
 import sixgaezzang.sidepeek.comments.dto.request.CommentRequest;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
 import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.common.doc.CommentControllerDoc;
 
 @RestController
 @RequestMapping("/projects/{projectId}/comments")
-@Tag(name = "Project Comment", description = "Project Comment API")
 @RequiredArgsConstructor
-public class CommentController {
+public class CommentController implements CommentControllerDoc {
 
+    @Override
     @PostMapping
-    @Operation(summary = "댓글 생성")
-    @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
     public ResponseEntity<CommentResponse> save(
-        @Schema(description = "로그인한 회원 식별자", example = "1")
-        @Login
-        Long loginId,
-
-        @Schema(description = "생성할 댓글의 프로젝트 식별자", example = "1")
-        @PathVariable
-        Long projectId,
-
-        @Valid
-        @RequestBody
-        CommentRequest request
+        @Login Long loginId,
+        @PathVariable Long projectId,
+        @Valid @RequestBody CommentRequest request
     ) {
         return null;
     }
 
+    @Override
     @PutMapping("/{id}")
-    @Operation(summary = "댓글 수정")
-    @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
     public ResponseEntity<CommentResponse> update(
-        @Schema(description = "로그인한 회원 식별자", example = "1")
-        @Login
-        Long loginId,
-
-        @Schema(description = "수정할 댓글의 프로젝트 식별자", example = "1")
-        @PathVariable
-        Long projectId,
-
-        @Schema(description = "수정할 댓글 식별자", example = "1")
-        @PathVariable(value = "id")
-        Long commentId,
-
-        @Valid
-        @RequestBody
+        @Login Long loginId,
+        @PathVariable Long projectId,
+        @PathVariable(value = "id") Long commentId,
         CommentRequest request
     ) {
         return null;
     }
 
+    @Override
     @DeleteMapping("/{id}")
-    @Operation(summary = "댓글 삭제")
-    @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
     public ResponseEntity<Void> delete(
-        @Schema(description = "로그인한 회원 식별자", example = "1")
-        @Login
-        Long loginId,
-
-        @Schema(description = "삭제할 댓글의 프로젝트 식별자", example = "1")
-        @PathVariable
-        Long projectId,
-
-        @Schema(description = "삭제할 댓글 식별자", example = "1")
-        @PathVariable(value = "id")
-        Long commentId
+        @Login Long loginId,
+        @PathVariable Long projectId,
+        @PathVariable(value = "id") Long commentId
     ) {
         return null;
     }

--- a/src/main/java/sixgaezzang/sidepeek/comments/dto/request/CommentRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/dto/request/CommentRequest.java
@@ -12,7 +12,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-@Schema(description = "댓글 생성/수정 요청 정보")
+@Schema(description = "댓글 생성/수정 요청")
 public record CommentRequest(
     @Schema(description = "댓글 작성자 식별자", example = "1")
     @Min(value = MIN_ID, message = "작성자 id는 " + MIN_ID + "보다 작을 수 없습니다.")
@@ -27,4 +27,5 @@ public record CommentRequest(
     @NotBlank(message = CONTENT_IS_NULL)
     String content
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/comments/dto/response/CommentResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/dto/response/CommentResponse.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.comments.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,8 +10,8 @@ import sixgaezzang.sidepeek.comments.domain.Comment;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
+@Schema(description = "댓글 정보")
 @Builder
-@Schema(description = "댓글 응답 정보")
 public record CommentResponse(
     @Schema(description = "댓글 식별자", example = "1")
     Long id,
@@ -18,10 +19,10 @@ public record CommentResponse(
     @Schema(description = "댓글 작성자 정보(익명 댓글은 null)")
     UserSummary user,
 
-    @Schema(description = "댓글 작성자와 로그인 사용자 일치 여부")
+    @Schema(description = "댓글 작성자와 로그인 사용자 일치 여부", example = "true")
     boolean isOwner,
 
-    @Schema(description = "익명 댓글 여부")
+    @Schema(description = "익명 댓글 여부", example = "true")
     boolean isAnonymous,
 
     @Schema(description = "댓글 내용", example = "우와 이 프로젝트 대박인데요?")

--- a/src/main/java/sixgaezzang/sidepeek/comments/dto/response/ReplyResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/dto/response/ReplyResponse.java
@@ -8,8 +8,8 @@ import sixgaezzang.sidepeek.comments.domain.Comment;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
-@Builder
 @Schema(description = "대댓글 응답 정보")
+@Builder
 public record ReplyResponse(
     @Schema(description = "댓글 식별자", example = "3")
     Long id,

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,7 +31,7 @@ public interface AuthControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<UserSummary> validateToken(Long loginId);
+    ResponseEntity<UserSummary> validateToken(@Parameter(hidden = true) Long loginId);
 
     @Operation(summary = "Access / Refresh Token 재발급")
     @ApiResponses({

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
@@ -1,8 +1,6 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,10 +21,6 @@ public interface AuthControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @Parameters({
-        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
-        @Parameter(name = "password", description = "비밀번호", example = "sidepeek6!")
     })
     ResponseEntity<LoginResponse> login(LoginRequest request);
 

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
@@ -3,19 +3,27 @@ package sixgaezzang.sidepeek.common.doc;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.auth.dto.request.LoginRequest;
 import sixgaezzang.sidepeek.auth.dto.request.ReissueTokenRequest;
 import sixgaezzang.sidepeek.auth.dto.response.LoginResponse;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 
 @Tag(name = "Auth", description = "회원 인증 API")
 public interface AuthControllerDoc {
 
     @Operation(summary = "이메일/비밀번호 로그인")
-    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameters({
         @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
         @Parameter(name = "password", description = "비밀번호", example = "sidepeek6!")
@@ -23,10 +31,18 @@ public interface AuthControllerDoc {
     ResponseEntity<LoginResponse> login(LoginRequest request);
 
     @Operation(summary = "Access Token 검증", description = "Access Token을 통해 현재 로그인 된 사용자의 정보를 응답받습니다.")
-    @ApiResponse(responseCode = "200", description = "Access Token 검증 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<UserSummary> validateToken(Long loginId);
 
     @Operation(summary = "Access / Refresh Token 재발급")
-    @ApiResponse(responseCode = "200", description = "Access / Refresh Token 재발급 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<LoginResponse> reissue(ReissueTokenRequest request);
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
@@ -14,7 +14,7 @@ import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 @Tag(name = "Auth", description = "회원 인증 API")
 public interface AuthControllerDoc {
 
-    @Operation(summary = "로그인")
+    @Operation(summary = "이메일/비밀번호 로그인")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @Parameters({
         @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
@@ -22,7 +22,7 @@ public interface AuthControllerDoc {
     })
     ResponseEntity<LoginResponse> login(LoginRequest request);
 
-    @Operation(summary = "Access Token 검증")
+    @Operation(summary = "Access Token 검증", description = "Access Token을 통해 현재 로그인 된 사용자의 정보를 응답받습니다.")
     @ApiResponse(responseCode = "200", description = "Access Token 검증 성공")
     ResponseEntity<UserSummary> validateToken(Long loginId);
 

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/AuthControllerDoc.java
@@ -1,0 +1,32 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.auth.dto.request.LoginRequest;
+import sixgaezzang.sidepeek.auth.dto.request.ReissueTokenRequest;
+import sixgaezzang.sidepeek.auth.dto.response.LoginResponse;
+import sixgaezzang.sidepeek.users.dto.response.UserSummary;
+
+@Tag(name = "Auth", description = "회원 인증 API")
+public interface AuthControllerDoc {
+
+    @Operation(summary = "로그인")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @Parameters({
+        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
+        @Parameter(name = "password", description = "비밀번호", example = "sidepeek6!")
+    })
+    ResponseEntity<LoginResponse> login(LoginRequest request);
+
+    @Operation(summary = "Access Token 검증")
+    @ApiResponse(responseCode = "200", description = "Access Token 검증 성공")
+    ResponseEntity<UserSummary> validateToken(Long loginId);
+
+    @Operation(summary = "Access / Refresh Token 재발급")
+    @ApiResponse(responseCode = "200", description = "Access / Refresh Token 재발급 성공")
+    ResponseEntity<LoginResponse> reissue(ReissueTokenRequest request);
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
@@ -24,7 +24,8 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "projectId", description = "생성할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH)
-    ResponseEntity<CommentResponse> save(Long loginId, Long projectId, CommentRequest request);
+    ResponseEntity<CommentResponse> save(@Parameter(hidden = true) Long loginId, Long projectId,
+        CommentRequest request);
 
     @Operation(summary = "댓글 수정")
     @ApiResponses(value = {
@@ -38,8 +39,8 @@ public interface CommentControllerDoc {
         @Parameter(name = "projectId", description = "수정할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
         @Parameter(name = "commentId", description = "수정할 댓글 ID", example = "1", in = ParameterIn.PATH)
     })
-    ResponseEntity<CommentResponse> update(Long loginId, Long projectId, Long commentId,
-        CommentRequest request);
+    ResponseEntity<CommentResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
+        Long commentId, CommentRequest request);
 
     @Operation(summary = "댓글 삭제")
     @ApiResponses(value = {
@@ -52,6 +53,7 @@ public interface CommentControllerDoc {
         @Parameter(name = "projectId", description = "삭제할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
         @Parameter(name = "commentId", description = "삭제할 댓글 ID", example = "1", in = ParameterIn.PATH)
     })
-    ResponseEntity<Void> delete(Long loginId, Long projectId, Long commentId);
+    ResponseEntity<Void> delete(@Parameter(hidden = true) Long loginId, Long projectId,
+        Long commentId);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
@@ -1,6 +1,9 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,11 +23,8 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<CommentResponse> save(
-        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
-        @Schema(description = "생성할 댓글의 프로젝트 식별자", example = "1") Long projectId,
-        CommentRequest request
-    );
+    @Parameter(name = "projectId", description = "생성할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH)
+    ResponseEntity<CommentResponse> save(Long loginId, Long projectId, CommentRequest request);
 
     @Operation(summary = "댓글 수정")
     @ApiResponses(value = {
@@ -34,12 +34,12 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<CommentResponse> update(
-        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
-        @Schema(description = "수정할 댓글의 프로젝트 식별자", example = "1") Long projectId,
-        @Schema(description = "수정할 댓글 식별자", example = "1") Long commentId,
-        CommentRequest request
-    );
+    @Parameters({
+        @Parameter(name = "projectId", description = "수정할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
+        @Parameter(name = "commentId", description = "수정할 댓글 ID", example = "1", in = ParameterIn.PATH)
+    })
+    ResponseEntity<CommentResponse> update(Long loginId, Long projectId, Long commentId,
+        CommentRequest request);
 
     @Operation(summary = "댓글 삭제")
     @ApiResponses(value = {
@@ -48,10 +48,10 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> delete(
-        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
-        @Schema(description = "삭제할 댓글의 프로젝트 식별자", example = "1") Long projectId,
-        @Schema(description = "삭제할 댓글 식별자", example = "1") Long commentId
-    );
+    @Parameters({
+        @Parameter(name = "projectId", description = "삭제할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
+        @Parameter(name = "commentId", description = "삭제할 댓글 ID", example = "1", in = ParameterIn.PATH)
+    })
+    ResponseEntity<Void> delete(Long loginId, Long projectId, Long commentId);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
@@ -1,18 +1,25 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.comments.dto.request.CommentRequest;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 
 @Tag(name = "Comment", description = "댓글 API")
 public interface CommentControllerDoc {
 
     @Operation(summary = "댓글 생성")
-    @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "CREATED", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<CommentResponse> save(
         @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
         @Schema(description = "생성할 댓글의 프로젝트 식별자", example = "1") Long projectId,
@@ -20,7 +27,13 @@ public interface CommentControllerDoc {
     );
 
     @Operation(summary = "댓글 수정")
-    @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<CommentResponse> update(
         @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
         @Schema(description = "수정할 댓글의 프로젝트 식별자", example = "1") Long projectId,
@@ -29,7 +42,12 @@ public interface CommentControllerDoc {
     );
 
     @Operation(summary = "댓글 삭제")
-    @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "NO_CONTENT"),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<Void> delete(
         @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
         @Schema(description = "삭제할 댓글의 프로젝트 식별자", example = "1") Long projectId,

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
@@ -23,7 +23,7 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "projectId", description = "생성할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH)
+    @Parameter(name = "projectId", description = "생성할 댓글의 프로젝트 식별자", example = "1", in = ParameterIn.PATH)
     ResponseEntity<CommentResponse> save(@Parameter(hidden = true) Long loginId, Long projectId,
         CommentRequest request);
 
@@ -36,8 +36,8 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "projectId", description = "수정할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
-        @Parameter(name = "commentId", description = "수정할 댓글 ID", example = "1", in = ParameterIn.PATH)
+        @Parameter(name = "projectId", description = "수정할 댓글의 프로젝트 식별자", example = "1", in = ParameterIn.PATH),
+        @Parameter(name = "id", description = "수정할 댓글 식별자", example = "1", in = ParameterIn.PATH)
     })
     ResponseEntity<CommentResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
         Long commentId, CommentRequest request);
@@ -50,8 +50,8 @@ public interface CommentControllerDoc {
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameters({
-        @Parameter(name = "projectId", description = "삭제할 댓글의 프로젝트 ID", example = "1", in = ParameterIn.PATH),
-        @Parameter(name = "commentId", description = "삭제할 댓글 ID", example = "1", in = ParameterIn.PATH)
+        @Parameter(name = "projectId", description = "삭제할 댓글의 프로젝트 식별자", example = "1", in = ParameterIn.PATH),
+        @Parameter(name = "id", description = "삭제할 댓글 식별자", example = "1", in = ParameterIn.PATH)
     })
     ResponseEntity<Void> delete(@Parameter(hidden = true) Long loginId, Long projectId,
         Long commentId);

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/CommentControllerDoc.java
@@ -1,0 +1,39 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.comments.dto.request.CommentRequest;
+import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
+
+@Tag(name = "Comment", description = "댓글 API")
+public interface CommentControllerDoc {
+
+    @Operation(summary = "댓글 생성")
+    @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
+    ResponseEntity<CommentResponse> save(
+        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
+        @Schema(description = "생성할 댓글의 프로젝트 식별자", example = "1") Long projectId,
+        CommentRequest request
+    );
+
+    @Operation(summary = "댓글 수정")
+    @ApiResponse(responseCode = "200", description = "댓글 수정 성공")
+    ResponseEntity<CommentResponse> update(
+        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
+        @Schema(description = "수정할 댓글의 프로젝트 식별자", example = "1") Long projectId,
+        @Schema(description = "수정할 댓글 식별자", example = "1") Long commentId,
+        CommentRequest request
+    );
+
+    @Operation(summary = "댓글 삭제")
+    @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
+    ResponseEntity<Void> delete(
+        @Schema(description = "로그인한 회원 식별자", example = "1") Long loginId,
+        @Schema(description = "삭제할 댓글의 프로젝트 식별자", example = "1") Long projectId,
+        @Schema(description = "삭제할 댓글 식별자", example = "1") Long commentId
+    );
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 import sixgaezzang.sidepeek.media.dto.response.MediaUploadResponse;
 
-@Tag(name = "Media", description = "Media(Image Upload) API")
+@Tag(name = "Media", description = "미디어(파일 업로드) API")
 public interface MediaControllerDoc {
 
     @Operation(summary = "파일 업로드")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -1,8 +1,6 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,9 +21,6 @@ public interface MediaControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<MediaUploadResponse> uploadFile(
-        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
-        @Parameter(name = "file", description = "업로드할 이미지 파일") MultipartFile file
-    );
+    ResponseEntity<MediaUploadResponse> uploadFile(Long loginId, MultipartFile file);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -4,22 +4,25 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.media.dto.response.MediaUploadResponse;
 
 @Tag(name = "Media", description = "미디어(파일 업로드) API")
 public interface MediaControllerDoc {
 
     @Operation(summary = "파일 업로드")
-    @ApiResponse(responseCode = "200", description = "파일 업로드 성공")
-    @ApiResponse(responseCode = "400",
-        description = "요청이 잘못된 경우(파일이 없거나 비어있는 경우. 이미지/비디오 형식이 아닌 경우. 최대 용량(100MB)를 넘은 경우.)",
-        content = @Content)
-    @ApiResponse(responseCode = "401", description = "로그인을 하지 않은 경우", content = @Content)
-    @ApiResponse(responseCode = "5XX", description = "파일 업로드 중 그 외 예외가 발생한 경우", content = @Content)
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<MediaUploadResponse> uploadFile(
         @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
         @Parameter(name = "file", description = "업로드할 이미지 파일") MultipartFile file

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -1,0 +1,28 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+import sixgaezzang.sidepeek.media.dto.response.MediaUploadResponse;
+
+@Tag(name = "Media", description = "Media(Image Upload) API")
+public interface MediaControllerDoc {
+
+    @Operation(summary = "파일 업로드")
+    @ApiResponse(responseCode = "200", description = "파일 업로드 성공")
+    @ApiResponse(responseCode = "400",
+        description = "요청이 잘못된 경우(파일이 없거나 비어있는 경우. 이미지/비디오 형식이 아닌 경우. 최대 용량(100MB)를 넘은 경우.)",
+        content = @Content)
+    @ApiResponse(responseCode = "401", description = "로그인을 하지 않은 경우", content = @Content)
+    @ApiResponse(responseCode = "5XX", description = "파일 업로드 중 그 외 예외가 발생한 경우", content = @Content)
+    ResponseEntity<MediaUploadResponse> uploadFile(
+        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
+        @Parameter(name = "file", description = "업로드할 이미지 파일") MultipartFile file
+    );
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/MediaControllerDoc.java
@@ -21,6 +21,7 @@ public interface MediaControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<MediaUploadResponse> uploadFile(Long loginId, MultipartFile file);
+    ResponseEntity<MediaUploadResponse> uploadFile(@Parameter(hidden = true) Long loginId,
+        MultipartFile file);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.common.exception.ErrorResponse;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
+import sixgaezzang.sidepeek.projects.dto.request.SaveProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 
@@ -26,7 +26,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ProjectResponse> save(@Parameter(hidden = true) Long loginId,
-        ProjectRequest request);
+                                         SaveProjectRequest request);
 
     @Operation(summary = "프로젝트 수정", description = "프로젝트 작성자와 멤버만 수정이 가능합니다.")
     @ApiResponses({
@@ -38,7 +38,7 @@ public interface ProjectControllerDoc {
     })
     @Parameter(name = "id", description = "수정할 프로젝트 식별자", in = ParameterIn.PATH)
     ResponseEntity<ProjectResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
-        ProjectRequest request);
+                                           SaveProjectRequest request);
 
     @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자만 삭제가 가능합니다.")
     @ApiResponses({

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -4,10 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
@@ -16,37 +20,57 @@ import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 public interface ProjectControllerDoc {
 
     @Operation(summary = "프로젝트 생성")
-    @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "CREATED", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<ProjectResponse> save(
         @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
         Long loginId,
         ProjectRequest request
     );
 
-    @Operation(summary = "프로젝트 수정")
-    @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공(프로젝트 작성자/회원 멤버만 가능)")
+    @Operation(summary = "프로젝트 수정", description = "프로젝트 작성자와 멤버만 수정이 가능합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<ProjectResponse> update(
         @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
         @Parameter(description = "수정할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId,
         ProjectRequest request
     );
 
-    @Operation(summary = "프로젝트 삭제")
-    @ApiResponse(responseCode = "204", description = "프로젝트 삭제 성공(프로젝트 작성자만 가능)")
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자만 삭제가 가능합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "NO_CONTENT"),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<Void> delete(
         @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
         @Parameter(description = "삭제할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId
     );
 
     @Operation(summary = "프로젝트 상세 조회")
-    @ApiResponse(responseCode = "200", description = "프로젝트 상세 조회 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<ProjectResponse> getById(
         @Parameter(description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
         Long id
     );
 
     @Operation(summary = "프로젝트 전체 조회")
-    @ApiResponse(responseCode = "200", description = "프로젝트 전체 조회 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true)
+    })
     @Parameters({
         @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER),
         @Parameter(name = "sort", description = "정렬 조건 [ createdAt(default), view, like ]", in = ParameterIn.QUERY),

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -12,7 +12,7 @@ import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 
-@Tag(name = "Project", description = "Project API")
+@Tag(name = "Project", description = "프로젝트 API")
 public interface ProjectControllerDoc {
 
     @Operation(summary = "프로젝트 생성")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -1,0 +1,60 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
+import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
+import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
+
+@Tag(name = "Project", description = "Project API")
+public interface ProjectControllerDoc {
+
+    @Operation(summary = "프로젝트 생성")
+    @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
+    ResponseEntity<ProjectResponse> save(
+        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
+        Long loginId,
+        ProjectRequest request
+    );
+
+    @Operation(summary = "프로젝트 수정")
+    @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공(프로젝트 작성자/회원 멤버만 가능)")
+    ResponseEntity<ProjectResponse> update(
+        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
+        @Parameter(description = "수정할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId,
+        ProjectRequest request
+    );
+
+    @Operation(summary = "프로젝트 삭제")
+    @ApiResponse(responseCode = "204", description = "프로젝트 삭제 성공(프로젝트 작성자만 가능)")
+    ResponseEntity<Void> delete(
+        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
+        @Parameter(description = "삭제할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId
+    );
+
+    @Operation(summary = "프로젝트 상세 조회")
+    @ApiResponse(responseCode = "200", description = "프로젝트 상세 조회 성공")
+    ResponseEntity<ProjectResponse> getById(
+        @Parameter(description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
+        Long id
+    );
+
+    @Operation(summary = "프로젝트 전체 조회")
+    @ApiResponse(responseCode = "200", description = "프로젝트 전체 조회 성공")
+    @Parameters({
+        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER),
+        @Parameter(name = "sort", description = "정렬 조건 [ createdAt(default), view, like ]", in = ParameterIn.QUERY),
+        @Parameter(name = "isReleased", description = "출시서비스만 보기", in = ParameterIn.QUERY)
+    })
+    ResponseEntity<List<ProjectListResponse>> getAll(
+        Long loginId,
+        String sort,
+        boolean isReleased
+    );
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -25,11 +25,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<ProjectResponse> save(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
-        Long loginId,
-        ProjectRequest request
-    );
+    ResponseEntity<ProjectResponse> save(Long loginId, ProjectRequest request);
 
     @Operation(summary = "프로젝트 수정", description = "프로젝트 작성자와 멤버만 수정이 가능합니다.")
     @ApiResponses({
@@ -39,11 +35,8 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<ProjectResponse> update(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
-        @Parameter(description = "수정할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId,
-        ProjectRequest request
-    );
+    @Parameter(name = "projectId", description = "수정할 프로젝트 ID", in = ParameterIn.PATH)
+    ResponseEntity<ProjectResponse> update(Long loginId, Long projectId, ProjectRequest request);
 
     @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자만 삭제가 가능합니다.")
     @ApiResponses({
@@ -52,33 +45,24 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> delete(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER) Long loginId,
-        @Parameter(description = "삭제할 프로젝트 식별자", in = ParameterIn.PATH) Long projectId
-    );
+    @Parameter(name = "projectId", description = "삭제할 프로젝트 ID", in = ParameterIn.PATH)
+    ResponseEntity<Void> delete(Long loginId, Long projectId);
 
     @Operation(summary = "프로젝트 상세 조회")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<ProjectResponse> getById(
-        @Parameter(description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
-        Long id
-    );
+    @Parameter(name = "id", description = "조회할 프로젝트 ID", in = ParameterIn.PATH)
+    ResponseEntity<ProjectResponse> getById(Long id);
 
     @Operation(summary = "프로젝트 전체 조회")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true)
     })
     @Parameters({
-        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER),
         @Parameter(name = "sort", description = "정렬 조건 [ createdAt(default), view, like ]", in = ParameterIn.QUERY),
-        @Parameter(name = "isReleased", description = "출시서비스만 보기", in = ParameterIn.QUERY)
+        @Parameter(name = "isReleased", description = "출시 서비스만 보기", in = ParameterIn.QUERY)
     })
-    ResponseEntity<List<ProjectListResponse>> getAll(
-        Long loginId,
-        String sort,
-        boolean isReleased
-    );
+    ResponseEntity<List<ProjectListResponse>> getAll(Long loginId, String sort, boolean isReleased);
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -36,7 +36,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "projectId", description = "수정할 프로젝트 ID", in = ParameterIn.PATH)
+    @Parameter(name = "id", description = "수정할 프로젝트 식별자", in = ParameterIn.PATH)
     ResponseEntity<ProjectResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
         ProjectRequest request);
 
@@ -55,7 +55,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "id", description = "조회할 프로젝트 ID", in = ParameterIn.PATH)
+    @Parameter(name = "id", description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
     ResponseEntity<ProjectResponse> getById(Long id);
 
     @Operation(summary = "프로젝트 전체 조회")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -25,7 +25,8 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<ProjectResponse> save(Long loginId, ProjectRequest request);
+    ResponseEntity<ProjectResponse> save(@Parameter(hidden = true) Long loginId,
+        ProjectRequest request);
 
     @Operation(summary = "프로젝트 수정", description = "프로젝트 작성자와 멤버만 수정이 가능합니다.")
     @ApiResponses({
@@ -36,7 +37,8 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "projectId", description = "수정할 프로젝트 ID", in = ParameterIn.PATH)
-    ResponseEntity<ProjectResponse> update(Long loginId, Long projectId, ProjectRequest request);
+    ResponseEntity<ProjectResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
+        ProjectRequest request);
 
     @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자만 삭제가 가능합니다.")
     @ApiResponses({
@@ -45,8 +47,8 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "projectId", description = "삭제할 프로젝트 ID", in = ParameterIn.PATH)
-    ResponseEntity<Void> delete(Long loginId, Long projectId);
+    @Parameter(name = "id", description = "삭제할 프로젝트 식별자", in = ParameterIn.PATH)
+    ResponseEntity<Void> delete(@Parameter(hidden = true) Long loginId, Long projectId);
 
     @Operation(summary = "프로젝트 상세 조회")
     @ApiResponses({
@@ -64,5 +66,6 @@ public interface ProjectControllerDoc {
         @Parameter(name = "sort", description = "정렬 조건 [ createdAt(default), view, like ]", in = ParameterIn.QUERY),
         @Parameter(name = "isReleased", description = "출시 서비스만 보기", in = ParameterIn.QUERY)
     })
-    ResponseEntity<List<ProjectListResponse>> getAll(Long loginId, String sort, boolean isReleased);
+    ResponseEntity<List<ProjectListResponse>> getAll(@Parameter(hidden = true) Long loginId,
+        String sort, boolean isReleased);
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
@@ -3,9 +3,11 @@ package sixgaezzang.sidepeek.common.doc;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
 
+@Tag(name = "Skill", description = "기술스택 API")
 public interface SkillControllerDoc {
 
     @Operation(summary = "기술 스택 검색")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
@@ -2,16 +2,23 @@ package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
 
 @Tag(name = "Skill", description = "기술스택 API")
 public interface SkillControllerDoc {
 
     @Operation(summary = "기술 스택 검색")
-    @ApiResponse(responseCode = "200", description = "기술 스택 검색 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameter(name = "keyword", description = "검색어", example = "spring")
     ResponseEntity<SkillSearchResponse> searchByName(
         String keyword

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
@@ -1,0 +1,18 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
+
+public interface SkillControllerDoc {
+
+    @Operation(summary = "기술 스택 검색")
+    @ApiResponse(responseCode = "200", description = "기술 스택 검색 성공")
+    @Parameter(name = "keyword", description = "검색어", example = "spring")
+    ResponseEntity<SkillSearchResponse> searchByName(
+        String keyword
+    );
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
@@ -2,6 +2,7 @@ package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -19,9 +20,7 @@ public interface SkillControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "keyword", description = "검색어", example = "spring")
-    ResponseEntity<SkillSearchResponse> searchByName(
-        String keyword
-    );
+    @Parameter(name = "keyword", description = "검색어", example = "spring", in = ParameterIn.QUERY)
+    ResponseEntity<SkillSearchResponse> searchByName(String keyword);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -1,0 +1,65 @@
+package sixgaezzang.sidepeek.common.doc;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.users.dto.request.CheckEmailRequest;
+import sixgaezzang.sidepeek.users.dto.request.CheckNicknameRequest;
+import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
+import sixgaezzang.sidepeek.users.dto.request.UpdatePasswordRequest;
+import sixgaezzang.sidepeek.users.dto.request.UpdateUserProfileRequest;
+import sixgaezzang.sidepeek.users.dto.response.CheckDuplicateResponse;
+import sixgaezzang.sidepeek.users.dto.response.UserProfileResponse;
+import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
+
+@Tag(name = "User", description = "User API")
+public interface UserControllerDoc {
+
+    @Operation(summary = "회원가입")
+    @ApiResponse(responseCode = "201", description = "회원가입 성공")
+    @Parameters({
+        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
+        @Parameter(name = "password", description = "영문/숫자/특수문자 포함 8자 이상", example = "sidepeek6!"),
+        @Parameter(name = "nickname", description = "닉네임", example = "육개짱"),
+    })
+    ResponseEntity<Void> signUp(SignUpRequest request);
+
+    @Operation(summary = "비밀번호 수정")
+    @ApiResponse(responseCode = "204", description = "비밀번호 수정 성공")
+    ResponseEntity<Void> updatePassword(
+        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
+        @Schema(description = "수정할 회원 식별자") Long id,
+        UpdatePasswordRequest request
+    );
+
+    @Operation(summary = "이메일 중복 확인")
+    @ApiResponse(responseCode = "200", description = "이메일 중복 확인 성공")
+    @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com")
+    ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(CheckEmailRequest request);
+
+    @Operation(summary = "닉네임 중복 확인")
+    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
+    @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
+    ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(CheckNicknameRequest request);
+
+    @Operation(summary = "회원 닉네임 검색")
+    @ApiResponse(responseCode = "200", description = "회원 검색 성공")
+    @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
+    ResponseEntity<UserSearchResponse> searchByNickname(String keyword);
+
+    @Operation(summary = "회원 프로필 정보 조회")
+    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
+    ResponseEntity<UserProfileResponse> getById(@Schema(description = "회원 식별자") Long id);
+
+    @Operation(summary = "회원 프로필 정보 수정")
+    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
+    ResponseEntity<UserProfileResponse> update(
+        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
+        @Schema(description = "수정할 회원 식별자") Long id,
+        UpdateUserProfileRequest request
+    );
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -37,7 +37,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "id", description = "수정할 회원 ID", example = "1")
+    @Parameter(name = "id", description = "수정할 회원 식별자", example = "1")
     ResponseEntity<Void> updatePassword(@Parameter(hidden = true) Long loginId, Long id,
         UpdatePasswordRequest request);
 
@@ -68,7 +68,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "id", description = "조회할 회원 ID", example = "1", in = ParameterIn.PATH)
+    @Parameter(name = "id", description = "조회할 회원 식별자", example = "1", in = ParameterIn.PATH)
     ResponseEntity<UserProfileResponse> getById(Long id);
 
     @Operation(summary = "회원 프로필 정보 수정")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -46,7 +46,7 @@ public interface UserControllerDoc {
     @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
     ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(CheckNicknameRequest request);
 
-    @Operation(summary = "회원 닉네임 검색")
+    @Operation(summary = "회원 검색", description = "닉네임으로 회원을 검색합니다.")
     @ApiResponse(responseCode = "200", description = "회원 검색 성공")
     @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     ResponseEntity<UserSearchResponse> searchByNickname(String keyword);

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -3,10 +3,13 @@ package sixgaezzang.sidepeek.common.doc;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.users.dto.request.CheckEmailRequest;
 import sixgaezzang.sidepeek.users.dto.request.CheckNicknameRequest;
 import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
@@ -20,7 +23,10 @@ import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
 public interface UserControllerDoc {
 
     @Operation(summary = "회원가입")
-    @ApiResponse(responseCode = "201", description = "회원가입 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "CREATED", useReturnTypeSchema = true),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameters({
         @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
         @Parameter(name = "password", description = "영문/숫자/특수문자 포함 8자 이상", example = "sidepeek6!"),
@@ -29,7 +35,13 @@ public interface UserControllerDoc {
     ResponseEntity<Void> signUp(SignUpRequest request);
 
     @Operation(summary = "비밀번호 수정")
-    @ApiResponse(responseCode = "204", description = "비밀번호 수정 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<Void> updatePassword(
         @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
         @Schema(description = "수정할 회원 식별자") Long id,
@@ -37,26 +49,45 @@ public interface UserControllerDoc {
     );
 
     @Operation(summary = "이메일 중복 확인")
-    @ApiResponse(responseCode = "200", description = "이메일 중복 확인 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com")
     ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(CheckEmailRequest request);
 
     @Operation(summary = "닉네임 중복 확인")
-    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
     ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(CheckNicknameRequest request);
 
     @Operation(summary = "회원 검색", description = "닉네임으로 회원을 검색합니다.")
-    @ApiResponse(responseCode = "200", description = "회원 검색 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     ResponseEntity<UserSearchResponse> searchByNickname(String keyword);
 
     @Operation(summary = "회원 프로필 정보 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
     ResponseEntity<UserProfileResponse> getById(@Schema(description = "회원 식별자") Long id);
 
     @Operation(summary = "회원 프로필 정보 수정")
-    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     ResponseEntity<UserProfileResponse> update(
         @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
         @Schema(description = "수정할 회원 식별자") Long id,

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -38,7 +38,8 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "id", description = "수정할 회원 ID", example = "1")
-    ResponseEntity<Void> updatePassword(Long loginId, Long id, UpdatePasswordRequest request);
+    ResponseEntity<Void> updatePassword(@Parameter(hidden = true) Long loginId, Long id,
+        UpdatePasswordRequest request);
 
     @Operation(summary = "이메일 중복 확인")
     @ApiResponses({
@@ -78,7 +79,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "id", description = "수정할 회원 ID", example = "1", in = ParameterIn.PATH)
-    ResponseEntity<UserProfileResponse> update(Long loginId, Long id,
+    @Parameter(name = "id", description = "수정할 회원 식별자", example = "1", in = ParameterIn.PATH)
+    ResponseEntity<UserProfileResponse> update(@Parameter(hidden = true) Long loginId, Long id,
         UpdateUserProfileRequest request);
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -16,7 +16,7 @@ import sixgaezzang.sidepeek.users.dto.response.CheckDuplicateResponse;
 import sixgaezzang.sidepeek.users.dto.response.UserProfileResponse;
 import sixgaezzang.sidepeek.users.dto.response.UserSearchResponse;
 
-@Tag(name = "User", description = "User API")
+@Tag(name = "User", description = "사용자 API")
 public interface UserControllerDoc {
 
     @Operation(summary = "회원가입")

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -2,7 +2,7 @@ package sixgaezzang.sidepeek.common.doc;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -27,11 +27,6 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "201", description = "CREATED", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameters({
-        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
-        @Parameter(name = "password", description = "영문/숫자/특수문자 포함 8자 이상", example = "sidepeek6!"),
-        @Parameter(name = "nickname", description = "닉네임", example = "육개짱"),
-    })
     ResponseEntity<Void> signUp(SignUpRequest request);
 
     @Operation(summary = "비밀번호 수정")
@@ -42,18 +37,14 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> updatePassword(
-        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
-        @Schema(description = "수정할 회원 식별자") Long id,
-        UpdatePasswordRequest request
-    );
+    @Parameter(name = "id", description = "수정할 회원 ID", example = "1")
+    ResponseEntity<Void> updatePassword(Long loginId, Long id, UpdatePasswordRequest request);
 
     @Operation(summary = "이메일 중복 확인")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com")
     ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(CheckEmailRequest request);
 
     @Operation(summary = "닉네임 중복 확인")
@@ -61,7 +52,6 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
     ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(CheckNicknameRequest request);
 
     @Operation(summary = "회원 검색", description = "닉네임으로 회원을 검색합니다.")
@@ -69,7 +59,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
+    @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6", in = ParameterIn.QUERY)
     ResponseEntity<UserSearchResponse> searchByNickname(String keyword);
 
     @Operation(summary = "회원 프로필 정보 조회")
@@ -77,8 +67,8 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
-    ResponseEntity<UserProfileResponse> getById(@Schema(description = "회원 식별자") Long id);
+    @Parameter(name = "id", description = "조회할 회원 ID", example = "1", in = ParameterIn.PATH)
+    ResponseEntity<UserProfileResponse> getById(Long id);
 
     @Operation(summary = "회원 프로필 정보 수정")
     @ApiResponses({
@@ -88,9 +78,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "403", description = "FORBIDDEN", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<UserProfileResponse> update(
-        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)") Long loginId,
-        @Schema(description = "수정할 회원 식별자") Long id,
-        UpdateUserProfileRequest request
-    );
+    @Parameter(name = "id", description = "수정할 회원 ID", example = "1", in = ParameterIn.PATH)
+    ResponseEntity<UserProfileResponse> update(Long loginId, Long id,
+        UpdateUserProfileRequest request);
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/ErrorResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/ErrorResponse.java
@@ -1,10 +1,15 @@
 package sixgaezzang.sidepeek.common.exception;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.http.HttpStatus;
 
+@Schema(description = "에러 응답")
 public record ErrorResponse(
+    @Schema(description = "HTTP 상태 코드", example = "BAD_REQUEST")
     HttpStatus status,
+    @Schema(description = "에러 코드", example = "400")
     int code,
+    @Schema(description = "에러 메시지", example = "유효하지 않은 요청입니다.")
     String message
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/config/SwaggerConfig.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package sixgaezzang.sidepeek.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,16 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        String authenticationScheme = "Access Token";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(
+            authenticationScheme);
+        Components components = new Components().addSecuritySchemes(authenticationScheme,
+            createAPIKeyScheme());
+
         return new OpenAPI()
-            .components(new Components())
-            .info(apiInfo());
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(components);
     }
 
     private Info apiInfo() {
@@ -21,5 +30,14 @@ public class SwaggerConfig {
             .title("Sidepeek API")
             .description("사이드픽 API 명세서 \uD83D\uDC40")
             .version("v1");
+    }
+
+    private SecurityScheme createAPIKeyScheme() {
+        return new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .bearerFormat("JWT")
+            .scheme("bearer")
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization");
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/media/controller/MediaController.java
+++ b/src/main/java/sixgaezzang/sidepeek/media/controller/MediaController.java
@@ -1,11 +1,5 @@
 package sixgaezzang.sidepeek.media.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,33 +9,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.common.doc.MediaControllerDoc;
 import sixgaezzang.sidepeek.media.dto.response.MediaUploadResponse;
 import sixgaezzang.sidepeek.media.service.MediaService;
 
 @RestController
 @RequestMapping("/files")
-@Tag(name = "Media", description = "Media(Image Upload) API")
 @RequiredArgsConstructor
-public class MediaController {
+public class MediaController implements MediaControllerDoc {
 
     private final MediaService mediaService;
 
+    @Override
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "파일 업로드")
-    @ApiResponse(responseCode = "200", description = "파일 업로드 성공")
-    @ApiResponse(responseCode = "400",
-        description = "요청이 잘못된 경우(파일이 없거나 비어있는 경우. 이미지/비디오 형식이 아닌 경우. 최대 용량(100MB)를 넘은 경우.)",
-        content = @Content)
-    @ApiResponse(responseCode = "401", description = "로그인을 하지 않은 경우", content = @Content)
-    @ApiResponse(responseCode = "5XX", description = "파일 업로드 중 그 외 예외가 발생한 경우", content = @Content)
     public ResponseEntity<MediaUploadResponse> uploadFile(
-        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
-        @Login
-        Long loginId,
-
-        @Parameter(name = "file", description = "업로드할 이미지 파일")
-        @RequestParam
-        MultipartFile file
+        @Login Long loginId,
+        @RequestParam MultipartFile file
     ) {
         return ResponseEntity.ok()
             .body(mediaService.uploadFile(loginId, file));

--- a/src/main/java/sixgaezzang/sidepeek/media/dto/response/MediaUploadResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/media/dto/response/MediaUploadResponse.java
@@ -1,8 +1,13 @@
 package sixgaezzang.sidepeek.media.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "미디어(파일) 업로드 응답")
 public record MediaUploadResponse(
+    @Schema(description = "파일 URL", example = "https://sidepeek.s3.ap-northeast-2.amazonaws.com/2024/03/05/20/17/00/1.jpg")
     String fileUrl
 ) {
+
     public static MediaUploadResponse from(String url) {
         return new MediaUploadResponse(url);
     }

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -1,11 +1,5 @@
 package sixgaezzang.sidepeek.projects.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -22,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.common.doc.ProjectControllerDoc;
 import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
@@ -29,19 +24,15 @@ import sixgaezzang.sidepeek.projects.service.ProjectService;
 
 @RestController
 @RequestMapping("/projects")
-@Tag(name = "Project", description = "Project API")
 @RequiredArgsConstructor
-public class ProjectController {
+public class ProjectController implements ProjectControllerDoc {
 
     private final ProjectService projectService;
 
+    @Override
     @PostMapping
-    @Operation(summary = "프로젝트 생성")
-    @ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
     public ResponseEntity<ProjectResponse> save(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
         @Login Long loginId,
-
         @Valid @RequestBody ProjectRequest request
     ) {
         ProjectResponse response = projectService.save(loginId, null, request);
@@ -53,16 +44,11 @@ public class ProjectController {
             .body(response);
     }
 
+    @Override
     @PutMapping("/{id}")
-    @Operation(summary = "프로젝트 수정")
-    @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공(프로젝트 작성자/회원 멤버만 가능)")
     public ResponseEntity<ProjectResponse> update(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
         @Login Long loginId,
-
-        @Parameter(description = "수정할 프로젝트 식별자", in = ParameterIn.PATH)
         @PathVariable(value = "id") Long projectId,
-
         @Valid @RequestBody ProjectRequest request
     ) {
         ProjectResponse response = projectService.save(loginId, projectId, request);
@@ -70,14 +56,10 @@ public class ProjectController {
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @DeleteMapping("/{id}")
-    @Operation(summary = "프로젝트 삭제")
-    @ApiResponse(responseCode = "204", description = "프로젝트 삭제 성공(프로젝트 작성자만 가능)")
     public ResponseEntity<Void> delete(
-        @Parameter(description = "로그인한 회원 식별자", in = ParameterIn.HEADER)
         @Login Long loginId,
-
-        @Parameter(description = "삭제할 프로젝트 식별자", in = ParameterIn.PATH)
         @PathVariable(value = "id") Long projectId
     ) {
         projectService.delete(loginId, projectId);
@@ -86,11 +68,9 @@ public class ProjectController {
             .build();
     }
 
+    @Override
     @GetMapping("/{id}")
-    @Operation(summary = "프로젝트 상세 조회")
-    @ApiResponse(responseCode = "200", description = "프로젝트 상세 조회 성공")
     public ResponseEntity<ProjectResponse> getById(
-        @Parameter(description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
         @PathVariable Long id
     ) {
         ProjectResponse response = projectService.findById(id);
@@ -98,14 +78,8 @@ public class ProjectController {
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @GetMapping
-    @Operation(summary = "프로젝트 전체 조회")
-    @ApiResponse(responseCode = "200", description = "프로젝트 전체 조회 성공")
-    @Parameters({
-        @Parameter(name = "loginId", description = "로그인한 회원 식별자", in = ParameterIn.HEADER),
-        @Parameter(name = "sort", description = "정렬 조건 [ createdAt(default), view, like ]", in = ParameterIn.QUERY),
-        @Parameter(name = "isReleased", description = "출시서비스만 보기", in = ParameterIn.QUERY)
-    })
     public ResponseEntity<List<ProjectListResponse>> getAll(
         @Login Long loginId,
         @RequestParam(required = false) String sort,

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.common.annotation.Login;
 import sixgaezzang.sidepeek.common.doc.ProjectControllerDoc;
-import sixgaezzang.sidepeek.projects.dto.request.ProjectRequest;
+import sixgaezzang.sidepeek.projects.dto.request.SaveProjectRequest;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectListResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 import sixgaezzang.sidepeek.projects.service.ProjectService;
@@ -33,7 +33,7 @@ public class ProjectController implements ProjectControllerDoc {
     @PostMapping
     public ResponseEntity<ProjectResponse> save(
         @Login Long loginId,
-        @Valid @RequestBody ProjectRequest request
+        @Valid @RequestBody SaveProjectRequest request
     ) {
         ProjectResponse response = projectService.save(loginId, null, request);
         URI uri = ServletUriComponentsBuilder.fromCurrentContextPath()
@@ -49,7 +49,7 @@ public class ProjectController implements ProjectControllerDoc {
     public ResponseEntity<ProjectResponse> update(
         @Login Long loginId,
         @PathVariable(value = "id") Long projectId,
-        @Valid @RequestBody ProjectRequest request
+        @Valid @RequestBody SaveProjectRequest request
     ) {
         ProjectResponse response = projectService.save(loginId, projectId, request);
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "프로젝트 생성 요청에서 프로젝트 멤버 정보")
 public record MemberSaveRequest(
-    @Schema(description = "회원 멤버 유저 Id(비회원 멤버이면 null)", example = "1")
+    @Schema(description = "회원 멤버 유저 식별자(비회원 멤버이면 null)", example = "1")
     @Min(value = MIN_ID, message = "멤버 회원 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     Long userId,
 
@@ -26,4 +26,5 @@ public record MemberSaveRequest(
     @NotBlank(message = "멤버 역할을 입력해주세요.")
     String role
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/MemberSaveRequest.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.projects.dto.request;
 
 import static sixgaezzang.sidepeek.common.util.CommonConstant.MIN_ID;
+import static sixgaezzang.sidepeek.projects.exception.message.MemberErrorMessage.MEMBER_ID_NEGATIVE_OR_ZERO;
 import static sixgaezzang.sidepeek.projects.exception.message.MemberErrorMessage.NON_FELLOW_MEMBER_NICKNAME_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.projects.exception.message.MemberErrorMessage.ROLE_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_ROLE_LENGTH;
@@ -14,7 +15,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "프로젝트 생성 요청에서 프로젝트 멤버 정보")
 public record MemberSaveRequest(
     @Schema(description = "회원 멤버 유저 식별자(비회원 멤버이면 null)", example = "1")
-    @Min(value = MIN_ID, message = "멤버 회원 id는 " + MIN_ID + "보다 작을 수 없습니다.")
+    @Min(value = MIN_ID, message = MEMBER_ID_NEGATIVE_OR_ZERO)
     Long userId,
 
     @Schema(description = "비회원 멤버 닉네임(회원 멤버이면 null)", example = " ")

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectRequest.java
@@ -43,7 +43,7 @@ import java.util.List;
 import org.hibernate.validator.constraints.URL;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
-@Schema(description = "프로젝트 생성/수정 요청 정보")
+@Schema(description = "프로젝트 생성/수정 요청")
 public record ProjectRequest(
     // Required
     @Schema(description = "프로젝트 제목", example = "사이드픽👀")
@@ -56,7 +56,7 @@ public record ProjectRequest(
     @NotBlank(message = OVERVIEW_IS_NULL)
     String overview,
 
-    @Schema(description = "프로젝트 작성자 Id(회원 식별자)", example = "1")
+    @Schema(description = "프로젝트 작성자 식별자(회원 식별자)", example = "1")
     @Min(value = MIN_ID, message = "작성자 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     @NotNull(message = OWNER_ID_IS_NULL)
     Long ownerId,

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSkillSaveRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/ProjectSkillSaveRequest.java
@@ -17,7 +17,7 @@ import sixgaezzang.sidepeek.skill.domain.Skill;
 
 @Schema(description = "프로젝트 생성 요청에서 프로젝트 기술 스택 정보")
 public record ProjectSkillSaveRequest(
-    @Schema(description = "기술 스택 Id", example = "1")
+    @Schema(description = "기술 스택 식별자", example = "1")
     @Min(value = MIN_ID, message = "스킬 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     @NotNull(message = SKILL_ID_IS_NULL)
     Long skillId,

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/MemberSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/MemberSummary.java
@@ -13,7 +13,7 @@ public record MemberSummary(
     Long id,
     @Schema(description = "프로젝트 멤버 역할", example = "백엔드")
     String role,
-    @Schema(description = "프로젝트 멤버 회원/비회원 상세정보")
+    @Schema(description = "프로젝트 멤버 회원/비회원 상세 정보")
     UserSummary userSummary
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
-@Schema(description = "프로젝트 상세조회 응답")
+@Schema(description = "프로젝트 상세 조회 응답")
 @Builder
 public record ProjectResponse(
     @Schema(description = "프로젝트 식별자", example = "1")
@@ -36,7 +36,7 @@ public record ProjectResponse(
     YearMonth startDate,
     @Schema(description = "프로젝트 종료 연-월", example = "2024-03")
     YearMonth endDate,
-    @Schema(description = "프로젝트 작성자 Id", example = "1")
+    @Schema(description = "프로젝트 작성자 식별자", example = "1")
     Long ownerId,
     @Schema(description = "프로젝트 멤버 목록")
     List<MemberSummary> members,

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectSkillSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectSkillSummary.java
@@ -12,7 +12,7 @@ public record ProjectSkillSummary(
     Long id,
     @Schema(description = "프로젝트 기술 스택 카테고리", example = "프론트엔드")
     String category,
-    @Schema(description = "프로젝트 기술 스택 상세정보")
+    @Schema(description = "프로젝트 기술 스택 상세 정보")
     SkillResponse skill
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/exception/message/MemberErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/exception/message/MemberErrorMessage.java
@@ -1,5 +1,6 @@
 package sixgaezzang.sidepeek.projects.exception.message;
 
+import static sixgaezzang.sidepeek.common.util.CommonConstant.MIN_ID;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_MEMBER_COUNT;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_ROLE_LENGTH;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
@@ -9,17 +10,20 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberErrorMessage {
+
     // Member List
     public static final String MEMBER_OVER_MAX_COUNT = "멤버 수는 " + MAX_MEMBER_COUNT + "명 미만이어야 합니다.";
     public static final String MEMBER_IS_EMPTY = "멤버 목록에는 최소 1명(작성자)을 포함해야합니다.";
     public static final String MEMBER_NOT_INCLUDE_OWNER = "멤버 목록에 작성자를 필수로 포함해야합니다.";
 
     // Member
-    public static final String ROLE_OVER_MAX_LENGTH = "멤버의 역할 이름은 " + MAX_ROLE_LENGTH + "자 미만이어야 합니다.";
+    public static final String ROLE_OVER_MAX_LENGTH =
+        "멤버의 역할 이름은 " + MAX_ROLE_LENGTH + "자 미만이어야 합니다.";
     public static final String ROLE_IS_NULL = "멤버 역할 이름을 입력해주세요.";
     public static final String USER_ID_OF_FELLOW_MEMBER_IS_NULL = "회원인 멤버의 유저 Id를 입력해주세요.";
     public static final String NON_FELLOW_MEMBER_NICKNAME_IS_NULL = "비회원 멤버 닉네임을 입력해주세요.";
     public static final String NON_FELLOW_MEMBER_NICKNAME_OVER_MAX_LENGTH =
         "비회원 멤버 닉네임은 " + MAX_NICKNAME_LENGTH + "자 미만이어야 합니다.";
     public static final String MEMBER_IS_INVALID = "회원인 멤버는 유저 Id를, 비회원인 멤버는 닉네임을 입력해주세요.";
+    public static final String MEMBER_ID_NEGATIVE_OR_ZERO = "멤버 id는 " + MIN_ID + "보다 작을 수 없습니다.";
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -1,6 +1,7 @@
 package sixgaezzang.sidepeek.skill.controller;
 
 import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
+import static sixgaezzang.sidepeek.skill.exception.message.SkillErrorMessage.SKILL_NAME_OVER_MAX_LENGTH;
 
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,7 @@ public class SkillController implements SkillControllerDoc {
     @GetMapping
     public ResponseEntity<SkillSearchResponse> searchByName(
         @RequestParam(required = false)
-        @Size(max = MAX_SKILL_NAME_LENGTH, message = "최대 " + MAX_SKILL_NAME_LENGTH
-            + "자의 키워드로 검색할 수 있습니다.") String keyword
+        @Size(max = MAX_SKILL_NAME_LENGTH, message = SKILL_NAME_OVER_MAX_LENGTH) String keyword
     ) {
         return ResponseEntity.ok()
             .body(skillService.searchByName(keyword));

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -2,9 +2,6 @@ package sixgaezzang.sidepeek.skill.controller;
 
 import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,24 +9,23 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import sixgaezzang.sidepeek.common.doc.SkillControllerDoc;
 import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
 import sixgaezzang.sidepeek.skill.serivce.SkillService;
 
 @RestController
 @RequestMapping("/skills")
 @RequiredArgsConstructor
-public class SkillController {
+public class SkillController implements SkillControllerDoc {
 
     private final SkillService skillService;
 
+    @Override
     @GetMapping
-    @Operation(summary = "기술 스택 검색")
-    @ApiResponse(responseCode = "200", description = "기술 스택 검색 성공")
-    @Parameter(name = "keyword", description = "검색어", example = "spring")
     public ResponseEntity<SkillSearchResponse> searchByName(
         @RequestParam(required = false)
-        @Size(max = MAX_SKILL_NAME_LENGTH, message = "최대 " + MAX_SKILL_NAME_LENGTH + "자의 키워드로 검색할 수 있습니다.")
-        String keyword
+        @Size(max = MAX_SKILL_NAME_LENGTH, message = "최대 " + MAX_SKILL_NAME_LENGTH
+            + "자의 키워드로 검색할 수 있습니다.") String keyword
     ) {
         return ResponseEntity.ok()
             .body(skillService.searchByName(keyword));

--- a/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/dto/response/SkillSearchResponse.java
@@ -1,9 +1,13 @@
 package sixgaezzang.sidepeek.skill.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import sixgaezzang.sidepeek.skill.domain.Skill;
 
+@Schema(description = "기술 스택 검색 결과")
 public record SkillSearchResponse(
+    @Schema(description = "기술 스택 목록")
     List<SkillResponse> skills
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/skill/exception/message/SkillErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/exception/message/SkillErrorMessage.java
@@ -1,17 +1,22 @@
 package sixgaezzang.sidepeek.skill.exception.message;
 
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.MAX_CATEGORY_LENGTH;
+import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SkillErrorMessage {
+
     public static final String SKILL_NOT_EXISTING = "Skill Id에 해당하는 스킬이 없습니다.";
     public static final String SKILL_IS_NULL = "기술 스택이 null 입니다.";
     public static final String SKILL_ID_IS_NULL = "기술 스택의 스택 Id를 입력해주세요";
+    public static final String SKILL_NAME_OVER_MAX_LENGTH = "기술 스택명은 " + MAX_SKILL_NAME_LENGTH
+        + "자 이하여야 합니다.";
 
     // Category
-    public static final String CATEGORY_OVER_MAX_LENGTH = "기술 스택 카테고리는 " + MAX_CATEGORY_LENGTH + "자 이하여야 합니다.";
+    public static final String CATEGORY_OVER_MAX_LENGTH =
+        "기술 스택 카테고리는 " + MAX_CATEGORY_LENGTH + "자 이하여야 합니다.";
     public static final String CATEGORY_IS_NULL = "기술 스택 카테고리를 입력해주세요.";
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -3,12 +3,6 @@ package sixgaezzang.sidepeek.users.controller;
 import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.net.URI;
@@ -24,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import sixgaezzang.sidepeek.common.annotation.Login;
+import sixgaezzang.sidepeek.common.doc.UserControllerDoc;
 import sixgaezzang.sidepeek.users.dto.request.CheckEmailRequest;
 import sixgaezzang.sidepeek.users.dto.request.CheckNicknameRequest;
 import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
@@ -36,20 +31,13 @@ import sixgaezzang.sidepeek.users.service.UserService;
 
 @RestController
 @RequestMapping("/users")
-@Tag(name = "User", description = "User API")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserControllerDoc {
 
     private final UserService userService;
 
+    @Override
     @PostMapping
-    @Operation(summary = "회원가입")
-    @ApiResponse(responseCode = "201", description = "회원가입 성공")
-    @Parameters({
-        @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com"),
-        @Parameter(name = "password", description = "영문/숫자/특수문자 포함 8자 이상", example = "sidepeek6!"),
-        @Parameter(name = "nickname", description = "닉네임", example = "육개짱"),
-    })
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
         Long id = userService.signUp(request);
         URI uri = ServletUriComponentsBuilder.fromCurrentContextPath()
@@ -60,31 +48,20 @@ public class UserController {
             .build();
     }
 
+    @Override
     @PutMapping("/{id}/password")
-    @Operation(summary = "비밀번호 수정")
-    @ApiResponse(responseCode = "204", description = "비밀번호 수정 성공")
     public ResponseEntity<Void> updatePassword(
-        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)")
-        @Login
-        Long loginId,
-
-        @Schema(description = "수정할 회원 식별자")
-        @PathVariable
-        Long id,
-
-        @RequestBody
-        @Valid
-        UpdatePasswordRequest request
+        @Login Long loginId,
+        @PathVariable Long id,
+        @RequestBody @Valid UpdatePasswordRequest request
     ) {
         // TODO: 비밀번호 변경 서비스 기능 구현
         return ResponseEntity.noContent()
             .build();
     }
 
+    @Override
     @PostMapping("/email/check")
-    @Operation(summary = "이메일 중복 확인")
-    @ApiResponse(responseCode = "200", description = "이메일 중복 확인 성공")
-    @Parameter(name = "email", description = "이메일", example = "sidepeek6@gmail.com")
     public ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(
         @RequestBody @Valid CheckEmailRequest request
     ) {
@@ -94,10 +71,8 @@ public class UserController {
             .body(response);
     }
 
+    @Override
     @PostMapping("/nickname/check")
-    @Operation(summary = "닉네임 중복 확인")
-    @ApiResponse(responseCode = "200", description = "닉네임 중복 확인 성공")
-    @Parameter(name = "nickname", description = "닉네임", example = "육개짱")
     public ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(
         @RequestBody @Valid CheckNicknameRequest request
     ) {
@@ -107,10 +82,8 @@ public class UserController {
             .body(response);
     }
 
+    @Override
     @GetMapping("/nickname")
-    @Operation(summary = "회원 닉네임 검색")
-    @ApiResponse(responseCode = "200", description = "회원 검색 성공")
-    @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6")
     public ResponseEntity<UserSearchResponse> searchByNickname(
         @RequestParam(required = false)
         @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
@@ -120,33 +93,19 @@ public class UserController {
             .body(userService.searchByNickname(keyword));
     }
 
+    @Override
     @GetMapping("/{id}")
-    @Operation(summary = "회원 프로필 정보 조회")
-    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
-    public ResponseEntity<UserProfileResponse> getById(
-        @Schema(description = "회원 식별자")
-        @PathVariable
-        Long id
-    ) {
+    public ResponseEntity<UserProfileResponse> getById(@PathVariable Long id) {
         // TODO: 프로필 정보 조회 서비스 로직 구현
         return null;
     }
 
+    @Override
     @PutMapping("/{id}")
-    @Operation(summary = "회원 프로필 정보 수정")
-    @ApiResponse(responseCode = "200", description = "회원 프로필 정보 조회 성공")
     public ResponseEntity<UserProfileResponse> update(
-        @Schema(description = "로그인한 회원 식별자(토큰에서 추출)")
-        @Login
-        Long loginId,
-
-        @Schema(description = "수정할 회원 식별자")
-        @PathVariable
-        Long id,
-
-        @RequestBody
-        @Valid
-        UpdateUserProfileRequest request
+        @Login Long loginId,
+        @PathVariable Long id,
+        @RequestBody @Valid UpdateUserProfileRequest request
     ) {
         // TODO: 프로필 정보 수정 서비스 로직 구현
         return null;

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
@@ -1,9 +1,12 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "이메일 중복 확인 요청")
 public record CheckEmailRequest(
+    @Schema(description = "이메일", example = "sidepeek@gmail.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckEmailRequest.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.EMAIL_FORMAT_INVALID;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.EMAIL_IS_NULL;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -7,8 +10,8 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "이메일 중복 확인 요청")
 public record CheckEmailRequest(
     @Schema(description = "이메일", example = "sidepeek@gmail.com")
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = EMAIL_IS_NULL)
+    @Email(message = EMAIL_FORMAT_INVALID)
     String email
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
@@ -3,10 +3,13 @@ package sixgaezzang.sidepeek.users.dto.request;
 import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "닉네임 중복 확인 요청")
 public record CheckNicknameRequest(
+    @Schema(description = "닉네임", example = "jinny")
     @NotBlank(message = "닉네임을 입력해주세요.")
     @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
     String nickname

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/CheckNicknameRequest.java
@@ -1,5 +1,6 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_IS_NULL;
 import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
 
@@ -10,7 +11,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "닉네임 중복 확인 요청")
 public record CheckNicknameRequest(
     @Schema(description = "닉네임", example = "jinny")
-    @NotBlank(message = "닉네임을 입력해주세요.")
+    @NotBlank(message = NICKNAME_IS_NULL)
     @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
     String nickname
 ) {

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
@@ -3,19 +3,24 @@ package sixgaezzang.sidepeek.users.dto.request;
 import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import sixgaezzang.sidepeek.users.domain.Password;
 
+@Schema(description = "회원가입 요청")
 public record SignUpRequest(
+    @Schema(description = "이메일", example = "sidepeek@gmail.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     String email,
+    @Schema(description = "비밀번호", example = "sidepeek123!")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
     String password,
+    @Schema(description = "닉네임", example = "jinny")
     @NotBlank(message = "닉네임을 입력해주세요.")
     @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
     String nickname

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/SignUpRequest.java
@@ -1,6 +1,10 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.EMAIL_FORMAT_INVALID;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.EMAIL_IS_NULL;
 import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.PASSWORD_FORMAT_INVALID;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.PASSWORD_IS_NULL;
 import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,12 +17,12 @@ import sixgaezzang.sidepeek.users.domain.Password;
 @Schema(description = "회원가입 요청")
 public record SignUpRequest(
     @Schema(description = "이메일", example = "sidepeek@gmail.com")
-    @NotBlank(message = "이메일을 입력해주세요.")
-    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = EMAIL_IS_NULL)
+    @Email(message = EMAIL_FORMAT_INVALID)
     String email,
     @Schema(description = "비밀번호", example = "sidepeek123!")
-    @NotBlank(message = "비밀번호를 입력해주세요.")
-    @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
+    @NotBlank(message = PASSWORD_IS_NULL)
+    @Pattern(regexp = Password.PASSWORD_REGXP, message = PASSWORD_FORMAT_INVALID)
     String password,
     @Schema(description = "닉네임", example = "jinny")
     @NotBlank(message = "닉네임을 입력해주세요.")

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdatePasswordRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import sixgaezzang.sidepeek.users.domain.Password;
 
-@Schema(description = "비밀번호 수정 요청 정보")
+@Schema(description = "비밀번호 수정 요청")
 public record UpdatePasswordRequest(
     @Schema(description = "기존 비밀번호", example = "sidepeek6!")
     @NotBlank(message = "기존 비밀번호를 입력해주세요.")
@@ -17,4 +17,5 @@ public record UpdatePasswordRequest(
     @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
     String password
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdatePasswordRequest.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.users.dto.request;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NEW_PASSWORD_IS_NULL;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.PASSWORD_FORMAT_INVALID;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -8,13 +11,13 @@ import sixgaezzang.sidepeek.users.domain.Password;
 @Schema(description = "비밀번호 수정 요청")
 public record UpdatePasswordRequest(
     @Schema(description = "기존 비밀번호", example = "sidepeek6!")
-    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
-    @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
+    @NotBlank(message = PASSWORD_FORMAT_INVALID)
+    @Pattern(regexp = Password.PASSWORD_REGXP, message = PASSWORD_FORMAT_INVALID)
     String originalPassword,
 
     @Schema(description = "새로운 비밀번호", example = "sidepeek678!")
-    @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
-    @Pattern(regexp = Password.PASSWORD_REGXP, message = "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.")
+    @NotBlank(message = NEW_PASSWORD_IS_NULL)
+    @Pattern(regexp = Password.PASSWORD_REGXP, message = PASSWORD_FORMAT_INVALID)
     String password
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdateUserProfileRequest.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
-@Schema(description = "회원 프로필 수정 요청 정보")
+@Schema(description = "회원 프로필 수정 요청")
 public record UpdateUserProfileRequest(
     @Schema(description = "회원 닉네임", example = "의진")
     @NotNull(message = NICKNAME_IS_NULL)
@@ -52,4 +52,5 @@ public record UpdateUserProfileRequest(
     @Schema(description = "회원 기술 스택 목록")
     List<UpdateUserSkillRequest> techStacks
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdateUserSkillRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/request/UpdateUserSkillRequest.java
@@ -14,7 +14,7 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "회원 수정 요청 내 회원 기술 스택 정보")
 public record UpdateUserSkillRequest(
-    @Schema(description = "기술 스택 Id", example = "1")
+    @Schema(description = "기술 스택 식별자", example = "1")
     @Min(value = MIN_ID, message = "스킬 id는 " + MIN_ID + "보다 작을 수 없습니다.")
     @NotNull(message = SKILL_ID_IS_NULL)
     Long skillId,
@@ -24,4 +24,5 @@ public record UpdateUserSkillRequest(
     @NotBlank(message = CATEGORY_IS_NULL)
     String category
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/CheckDuplicateResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/CheckDuplicateResponse.java
@@ -1,6 +1,10 @@
 package sixgaezzang.sidepeek.users.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "중복 확인 응답")
 public record CheckDuplicateResponse(
+    @Schema(description = "중복 여부", example = "true")
     boolean isDuplicated
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSearchResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSearchResponse.java
@@ -1,9 +1,12 @@
 package sixgaezzang.sidepeek.users.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import sixgaezzang.sidepeek.users.domain.User;
 
+@Schema(description = "회원 검색 응답")
 public record UserSearchResponse(
+    @Schema(description = "회원 목록")
     List<UserSummary> users
 ) {
 

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSkillSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSkillSummary.java
@@ -13,7 +13,8 @@ public record UserSkillSummary(
     @Schema(description = "회원 기술 스택 카테고리", example = "프론트엔드")
     String category,
 
-    @Schema(description = "기술 스택 상세정보")
+    @Schema(description = "기술 스택 상세 정보")
     SkillResponse skill
 ) {
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import sixgaezzang.sidepeek.users.domain.User;
 
-@Schema(description = "회원 상세정보")
+@Schema(description = "회원 상세 정보")
 @Builder
 public record UserSummary(
     @Schema(description = "회원 식별자(비회원은 null)", example = "1")

--- a/src/main/java/sixgaezzang/sidepeek/users/exception/message/UserErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/exception/message/UserErrorMessage.java
@@ -13,19 +13,28 @@ import lombok.NoArgsConstructor;
 public class UserErrorMessage {
 
     public static final String USER_NOT_EXISTING = "User Id에 해당하는 회원이 없습니다.";
+
+    // Nickname
     public static final String NICKNAME_IS_NULL = "닉네임을 입력해주세요.";
     public static final String NICKNAME_OVER_MAX_LENGTH =
         "닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하여야 합니다.";
     public static final String NICKNAME_DUPLICATE = "이미 사용중인 닉네임입니다.";
+
+    // Email
+    public static final String EMAIL_FORMAT_INVALID = "이메일 형식이 올바르지 않습니다.";
+    public static final String EMAIL_DUPLICATE = "이미 사용중인 이메일입니다.";
+    public static final String EMAIL_IS_NULL = "이메일을 입력해주세요.";
+
+    // Password
+    public static final String PASSWORD_FORMAT_INVALID = "비밀번호 형식이 올바르지 않습니다.";
+    public static final String PASSWORD_IS_NULL = "비밀번호를 입력해주세요.";
+    public static final String NEW_PASSWORD_IS_NULL = "새로운 비밀번호를 입력해주세요.";
+
+    // 그 외
     public static final String INTRODUCTION_OVER_MAX_LENGTH =
         "소개글은 " + MAX_INTRODUCTION_LENGTH + "자 이하여야 합니다.";
     public static final String JOB_OVER_MAX_LENGTH = "직업은 " + MAX_JOB_LENGTH + "자 이하여야 합니다.";
     public static final String CAREER_OVER_MAX_LENGTH = "경력은 " + MAX_CAREER_LENGTH + "자 이하여야 합니다.";
     public static final String BLOG_URL_OVER_MAX_LENGTH =
         "블로그 URL은" + MAX_TEXT_LENGTH + "자 이하여야 합니다.";
-    public static final String EMAIL_FORMAT_INVALID = "이메일 형식이 올바르지 않습니다.";
-    public static final String EMAIL_DUPLICATE = "이미 사용중인 이메일입니다.";
-    public static final String PASSWORD_FORMAT_INVALID = "비밀번호 형식이 올바르지 않습니다.";
-    public static final String PASSWORD_IS_NULL = "비밀번호를 입력해주세요.";
-
 }


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #99 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 스웨거 UI 개선
  - 알파벳 순으로 태그 정렬
  - HTTP 메서드 순으로 API 정렬
  - 스웨거 url 간단한게 변경 (`http://{ip}:8080/api/v1/swagger-ui.html`)
  - 기본 consumes / produces를 application/json으로 설정
- [x] JWT 설정 추가 (Authorization)
- [x] 자세한 API 명세 작성 및 API 형식을 일관성있게 리팩토링
  - `@ApiResponse`에 에러 코드 추가
  - `@Operation`을 통한 기능 설명
  - `@Schema`을 통한 요청/응답 객체 명세 작성
  - `@Tag`로 API 그룹핑
  - `@Parameter`로 Path Variable, Request Param 명세

## 💬 코멘트
- [Swagger로 API 문서화를 해보자!](https://www.notion.so/prgrms/Swagger-API-7c027318b13f4ebcb0f31560055ccf23?pvs=4) 스웨거 적용 방식에 대해 블로깅도 했으니, 참고 부탁드립니당😊
- pull 받으셔서 로컬로 실행 후 `http://localhost:8080/api/v1/swagger-ui.html`로 확인해보시는 것을 추천 드립니당!
