### PR TITLE
afterMigrate.sql 설정에 스킬 데이터 21개 추가 

### DIFF
--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -60,13 +60,47 @@ values (2, 1, 'OVERVIEW_IMAGE', 'https://project-images.sidepeek.com/2.png');
 
 -- SKILL
 insert into skill(id, name, icon_image_url)
-values (1, 'React', 'https://cdn.iconscout.com/icon/react.png');
+values (1, 'AWS EC2', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/aws-ec2.png');
 insert into skill(id, name, icon_image_url)
-values (2, 'Spring', 'https://cdn.iconscout.com/icon/spring.png');
+values (2, 'AWS RDS', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/aws-rds.png');
 insert into skill(id, name, icon_image_url)
-values (3, 'GitHub', 'https://cdn.iconscout.com/icon/github.png');
+values (3, 'AWS S3', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/aws-s3.png');
 insert into skill(id, name, icon_image_url)
-values (4, 'React Query', 'https://cdn.iconscout.com/icon/reactQuery.png');
+values (4, 'Figma', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/figma.png');
+insert into skill(id, name, icon_image_url)
+values (5, 'Git', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/git-icon.png');
+insert into skill(id, name, icon_image_url)
+values (6, 'Github Actions', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/github-actions.png');
+insert into skill(id, name, icon_image_url)
+values (7, 'Github', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/github-icon.png');
+insert into skill(id, name, icon_image_url)
+values (8, 'Java', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/java.png');
+insert into skill(id, name, icon_image_url)
+values (9, 'Javascript', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/javascript.png');
+insert into skill(id, name, icon_image_url)
+values (10, 'Kotlin', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/kotlin-icon.png');
+insert into skill(id, name, icon_image_url)
+values (11, 'Notion', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/notion-icon.png');
+insert into skill(id, name, icon_image_url)
+values (12, 'PostgreSQL', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/postgresql.png');
+insert into skill(id, name, icon_image_url)
+values (13, 'React Query', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/react-query-icon.png');
+insert into skill(id, name, icon_image_url)
+values (14, 'React', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/react.png');
+insert into skill(id, name, icon_image_url)
+values (15, 'Slack', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/slack-icon.png');
+insert into skill(id, name, icon_image_url)
+values (16, 'Spring', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/spring-icon.png');
+insert into skill(id, name, icon_image_url)
+values (17, 'Swagger', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/swagger.png');
+insert into skill(id, name, icon_image_url)
+values (18, 'Thymeleaf', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/thymeleaf-icon.png');
+insert into skill(id, name, icon_image_url)
+values (19, 'Tomcat', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/tomcat.png');
+insert into skill(id, name, icon_image_url)
+values (20, 'Typescript', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/typescript-icon.png');
+insert into skill(id, name, icon_image_url)
+values (21, 'Vercel', 'https://sidepeek-bucket.s3.ap-northeast-2.amazonaws.com/skill/vercel-icon.png');
 
 -- PROJECT_SKILL
 insert into project_skill(id, project_id, skill_id, category)


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #111 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] afterMigrate.sql 설정에 스킬 데이터 21개 추가 

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 앞 PR을 머지해야 머지할 수 있..습닏..다..! 죄송합니다!!!!!!😭