### PR TITLE
기술 스택 검색, 회원 닉네임 검색 에러 해결 #132

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/SkillControllerDoc.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.common.doc;
 
+import static sixgaezzang.sidepeek.skill.domain.Skill.MAX_SKILL_NAME_LENGTH;
+import static sixgaezzang.sidepeek.skill.exception.message.SkillErrorMessage.SKILL_NAME_OVER_MAX_LENGTH;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -8,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.skill.dto.response.SkillSearchResponse;
@@ -21,6 +25,8 @@ public interface SkillControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "keyword", description = "검색어", example = "spring", in = ParameterIn.QUERY)
-    ResponseEntity<SkillSearchResponse> searchByName(String keyword);
+    ResponseEntity<SkillSearchResponse> searchByName(
+        @Size(max = MAX_SKILL_NAME_LENGTH, message = SKILL_NAME_OVER_MAX_LENGTH) String keyword
+    );
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/UserControllerDoc.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.common.doc;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.NICKNAME_OVER_MAX_LENGTH;
+import static sixgaezzang.sidepeek.users.util.UserConstant.MAX_NICKNAME_LENGTH;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -8,6 +11,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import org.springframework.http.ResponseEntity;
 import sixgaezzang.sidepeek.common.exception.ErrorResponse;
 import sixgaezzang.sidepeek.users.dto.request.CheckEmailRequest;
@@ -27,7 +32,7 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "201", description = "CREATED", useReturnTypeSchema = true),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<Void> signUp(SignUpRequest request);
+    ResponseEntity<Void> signUp(@Valid SignUpRequest request);
 
     @Operation(summary = "비밀번호 수정")
     @ApiResponses({
@@ -39,21 +44,21 @@ public interface UserControllerDoc {
     })
     @Parameter(name = "id", description = "수정할 회원 식별자", example = "1")
     ResponseEntity<Void> updatePassword(@Parameter(hidden = true) Long loginId, Long id,
-        UpdatePasswordRequest request);
+                                        @Valid UpdatePasswordRequest request);
 
     @Operation(summary = "이메일 중복 확인")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(CheckEmailRequest request);
+    ResponseEntity<CheckDuplicateResponse> checkEmailDuplicate(@Valid CheckEmailRequest request);
 
     @Operation(summary = "닉네임 중복 확인")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(CheckNicknameRequest request);
+    ResponseEntity<CheckDuplicateResponse> checkNicknameDuplicate(@Valid CheckNicknameRequest request);
 
     @Operation(summary = "회원 검색", description = "닉네임으로 회원을 검색합니다.")
     @ApiResponses({
@@ -61,7 +66,10 @@ public interface UserControllerDoc {
         @ApiResponse(responseCode = "400", description = "BAD_REQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "keyword", description = "검색어", example = "sixgaezzang6", in = ParameterIn.QUERY)
-    ResponseEntity<UserSearchResponse> searchByNickname(String keyword);
+    ResponseEntity<UserSearchResponse> searchByNickname(
+        @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
+        String keyword
+    );
 
     @Operation(summary = "회원 프로필 정보 조회")
     @ApiResponses({
@@ -81,5 +89,5 @@ public interface UserControllerDoc {
     })
     @Parameter(name = "id", description = "수정할 회원 식별자", example = "1", in = ParameterIn.PATH)
     ResponseEntity<UserProfileResponse> update(@Parameter(hidden = true) Long loginId, Long id,
-        UpdateUserProfileRequest request);
+                                               @Valid UpdateUserProfileRequest request);
 }

--- a/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
+++ b/src/main/java/sixgaezzang/sidepeek/skill/controller/SkillController.java
@@ -24,8 +24,8 @@ public class SkillController implements SkillControllerDoc {
     @Override
     @GetMapping
     public ResponseEntity<SkillSearchResponse> searchByName(
-        @RequestParam(required = false)
-        @Size(max = MAX_SKILL_NAME_LENGTH, message = SKILL_NAME_OVER_MAX_LENGTH) String keyword
+        @Size(max = MAX_SKILL_NAME_LENGTH, message = SKILL_NAME_OVER_MAX_LENGTH)
+        @RequestParam(required = false) String keyword
     ) {
         return ResponseEntity.ok()
             .body(skillService.searchByName(keyword));

--- a/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/controller/UserController.java
@@ -85,9 +85,8 @@ public class UserController implements UserControllerDoc {
     @Override
     @GetMapping("/nickname")
     public ResponseEntity<UserSearchResponse> searchByNickname(
-        @RequestParam(required = false)
         @Size(max = MAX_NICKNAME_LENGTH, message = NICKNAME_OVER_MAX_LENGTH)
-        String keyword
+        @RequestParam(required = false) String keyword
     ) {
         return ResponseEntity.ok()
             .body(userService.searchByNickname(keyword));

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -91,6 +91,7 @@ public class UserService {
         return UserProfileResponse.from(user, techStacks);
     }
 
+    @Transactional
     public UserProfileResponse updateProfile(Long loginId, Long id, UpdateUserProfileRequest request) {
         validateLoginIdEqualsUserId(loginId, id);
 


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #132 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] #132

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 인터페이스를 이용해서 컨트롤러를 구현한 경우에는 jakarta.validation 계열 어노테이션을 똑같이 붙여줘야한다. 안그러면  jakarta.validation에서 아래 예외를 발생시킨다. 
- 이상한 점은 쿼리 스트링 적용을 한 메서드에서만 일어난다는 것이다.
```
jakarta.validation.ConstraintDeclarationException: HV000151: A method overriding another method must not redefine the parameter constraint configuration, ~
```