### PR TITLE
UserSummary, UserProfileResponse에 isSocialLogin 추가

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/auth/repository/AuthProviderRepository.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/repository/AuthProviderRepository.java
@@ -2,8 +2,9 @@ package sixgaezzang.sidepeek.auth.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sixgaezzang.sidepeek.auth.domain.AuthProvider;
+import sixgaezzang.sidepeek.users.domain.User;
 
 public interface AuthProviderRepository extends JpaRepository<AuthProvider, Long>,
     AuthProviderRepositoryCustom {
-
+    boolean existsByUser(User user);
 }

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
@@ -46,7 +46,7 @@ public class AuthService {
         User user = getUserById(userRepository.findById(loginId));
         boolean isSocialLogin = authProviderRepository.existsByUser(user);
 
-        return UserSummary.from(user, isSocialLogin);
+        return UserSummary.fromWithIsSocialLogin(user, isSocialLogin);
     }
 
     public LoginResponse reissue(ReissueTokenRequest request) {
@@ -72,7 +72,7 @@ public class AuthService {
         return LoginResponse.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken)
-            .user(UserSummary.from(user, isSocialLogin))
+            .user(UserSummary.fromWithIsSocialLogin(user, isSocialLogin))
             .build();
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
@@ -1,6 +1,9 @@
 package sixgaezzang.sidepeek.auth.service;
 
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.USER_NOT_EXISTING;
+
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,6 +14,7 @@ import sixgaezzang.sidepeek.auth.dto.request.LoginRequest;
 import sixgaezzang.sidepeek.auth.dto.request.ReissueTokenRequest;
 import sixgaezzang.sidepeek.auth.dto.response.LoginResponse;
 import sixgaezzang.sidepeek.auth.jwt.JWTManager;
+import sixgaezzang.sidepeek.auth.repository.AuthProviderRepository;
 import sixgaezzang.sidepeek.common.annotation.Login;
 import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.users.domain.User;
@@ -23,13 +27,13 @@ import sixgaezzang.sidepeek.users.repository.UserRepository;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final AuthProviderRepository authProviderRepository;
     private final RefreshTokenService refreshTokenService;
     private final PasswordEncoder passwordEncoder;
     private final JWTManager jwtManager;
 
     public LoginResponse login(LoginRequest request) {
-        User user = userRepository.findByEmail(request.email())
-            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        User user = getUserById(userRepository.findByEmail(request.email()));
 
         if (!user.checkPassword(request.password(), passwordEncoder)) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
@@ -39,10 +43,10 @@ public class AuthService {
     }
 
     public UserSummary loadUser(@Login Long loginId) {
-        User user = userRepository.findById(loginId)
-            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        User user = getUserById(userRepository.findById(loginId));
+        boolean isSocialLogin = authProviderRepository.existsByUser(user);
 
-        return UserSummary.from(user);
+        return UserSummary.from(user, isSocialLogin);
     }
 
     public LoginResponse reissue(ReissueTokenRequest request) {
@@ -52,8 +56,7 @@ public class AuthService {
 
         validateRefreshToken(redisRefreshToken.refreshToken(), refreshToken);
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        User user = getUserById(userRepository.findById(userId));
 
         return createTokens(user);
     }
@@ -64,11 +67,18 @@ public class AuthService {
         String refreshToken = jwtManager.generateRefreshToken(user.getId());
         refreshTokenService.save(refreshToken);
 
+        boolean isSocialLogin = authProviderRepository.existsByUser(user);
+
         return LoginResponse.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken)
-            .user(UserSummary.from(user))
+            .user(UserSummary.from(user, isSocialLogin))
             .build();
+    }
+
+    private User getUserById(Optional<User> userRepository) {
+        return userRepository
+            .orElseThrow(() -> new EntityNotFoundException(USER_NOT_EXISTING));
     }
 
     private void validateRefreshToken(String redisRefreshToken, String refreshToken) {

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserProfileResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserProfileResponse.java
@@ -38,7 +38,7 @@ public record UserProfileResponse(
     @Schema(description = "회원 기술 스택 목록")
     List<UserSkillSummary> techStacks
 ) {
-    public static UserProfileResponse from(User user, List<UserSkillSummary> techStacks) {
+    public static UserProfileResponse from(User user, boolean isSocialLogin, List<UserSkillSummary> techStacks) {
         Job userJob = user.getJob();
         String jobName = Objects.nonNull(userJob) ? userJob.getName() : null;
 
@@ -46,7 +46,7 @@ public record UserProfileResponse(
         String careerDescription = Objects.nonNull(userCareer) ? userCareer.getDescription() : null;
 
         return UserProfileResponse.builder()
-//            .isSocialLogin()
+            .isSocialLogin(isSocialLogin)
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImageUrl())
             .introduction(user.getIntroduction())

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserProfileResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserProfileResponse.java
@@ -11,6 +11,9 @@ import sixgaezzang.sidepeek.users.domain.User;
 @Schema(description = "회원 프로필 정보")
 @Builder
 public record UserProfileResponse(
+    @Schema(description = "소셜 로그인 회원 여부", example = "false")
+    boolean isSocialLogin,
+
     @Schema(description = "회원/비회원 닉네임", example = "의진")
     String nickname,
 
@@ -43,6 +46,7 @@ public record UserProfileResponse(
         String careerDescription = Objects.nonNull(userCareer) ? userCareer.getDescription() : null;
 
         return UserProfileResponse.builder()
+//            .isSocialLogin()
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImageUrl())
             .introduction(user.getIntroduction())

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -7,20 +7,21 @@ import sixgaezzang.sidepeek.users.domain.User;
 @Schema(description = "회원 상세 정보")
 @Builder
 public record UserSummary(
-    @Schema(description = "회원 식별자(비회원은 null)", example = "1")
+    @Schema(description = "회원 식별자(비회원은 null)", nullable = true, example = "1")
     Long id,
 
-    @Schema(description = "소셜 로그인 회원 여부", example = "false")
-    boolean isSocialLogin,
+    @Schema(description = "소셜 로그인 회원 여부", nullable = true, example = "false")
+    Boolean isSocialLogin,
 
     @Schema(description = "회원/비회원 닉네임", example = "의진")
     String nickname,
 
-    @Schema(description = "회원 프로필 이미지(비회원은 null)", example = "https://user-images.githubusercontent.com/uijin.png")
+    @Schema(description = "회원 프로필 이미지(비회원은 null)", nullable = true,
+        example = "https://user-images.githubusercontent.com/uijin.png")
     String profileImageUrl
 ) {
 
-    public static UserSummary from(User user, boolean isSocialLogin) {
+    public static UserSummary fromWithIsSocialLogin(User user, boolean isSocialLogin) {
         return UserSummary.builder()
             .id(user.getId())
             .isSocialLogin(isSocialLogin)
@@ -29,11 +30,20 @@ public record UserSummary(
             .build();
     }
 
-    // 멤버(회원)
-    public static UserSummary from(User user, String nickname, boolean isSocialLogin) {
+    public static UserSummary from(User user) {
         return UserSummary.builder()
             .id(user.getId())
-            .isSocialLogin(isSocialLogin)
+            .isSocialLogin(null)
+            .nickname(user.getNickname())
+            .profileImageUrl(user.getProfileImageUrl())
+            .build();
+    }
+
+    // 멤버(회원)
+    public static UserSummary from(User user, String nickname) {
+        return UserSummary.builder()
+            .id(user.getId())
+            .isSocialLogin(null)
             .nickname(nickname)
             .profileImageUrl(user.getProfileImageUrl())
             .build();
@@ -43,7 +53,7 @@ public record UserSummary(
     public static UserSummary from(String nickname) {
         return UserSummary.builder()
             .id(null)
-            .isSocialLogin(false)
+            .isSocialLogin(null)
             .nickname(nickname)
             .profileImageUrl(null)
             .build();

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -21,6 +21,10 @@ public record UserSummary(
     String profileImageUrl
 ) {
 
+    public UserSummary(Long id, String nickname, String profileImageUrl) {
+        this(id, null, nickname, profileImageUrl);
+    }
+
     public static UserSummary fromWithIsSocialLogin(User user, boolean isSocialLogin) {
         return UserSummary.builder()
             .id(user.getId())

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -20,19 +20,20 @@ public record UserSummary(
     String profileImageUrl
 ) {
 
-    public static UserSummary from(User user) {
+    public static UserSummary from(User user, boolean isSocialLogin) {
         return UserSummary.builder()
             .id(user.getId())
-//            .isSocialLogin()
+            .isSocialLogin(isSocialLogin)
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImageUrl())
             .build();
     }
 
     // 멤버(회원)
-    public static UserSummary from(User user, String nickname) {
+    public static UserSummary from(User user, String nickname, boolean isSocialLogin) {
         return UserSummary.builder()
             .id(user.getId())
+            .isSocialLogin(isSocialLogin)
             .nickname(nickname)
             .profileImageUrl(user.getProfileImageUrl())
             .build();
@@ -42,6 +43,7 @@ public record UserSummary(
     public static UserSummary from(String nickname) {
         return UserSummary.builder()
             .id(null)
+            .isSocialLogin(false)
             .nickname(nickname)
             .profileImageUrl(null)
             .build();

--- a/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/dto/response/UserSummary.java
@@ -9,8 +9,13 @@ import sixgaezzang.sidepeek.users.domain.User;
 public record UserSummary(
     @Schema(description = "회원 식별자(비회원은 null)", example = "1")
     Long id,
+
+    @Schema(description = "소셜 로그인 회원 여부", example = "false")
+    boolean isSocialLogin,
+
     @Schema(description = "회원/비회원 닉네임", example = "의진")
     String nickname,
+
     @Schema(description = "회원 프로필 이미지(비회원은 null)", example = "https://user-images.githubusercontent.com/uijin.png")
     String profileImageUrl
 ) {
@@ -18,6 +23,7 @@ public record UserSummary(
     public static UserSummary from(User user) {
         return UserSummary.builder()
             .id(user.getId())
+//            .isSocialLogin()
             .nickname(user.getNickname())
             .profileImageUrl(user.getProfileImageUrl())
             .build();

--- a/src/main/java/sixgaezzang/sidepeek/users/exception/message/UserErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/exception/message/UserErrorMessage.java
@@ -15,7 +15,7 @@ public final class UserErrorMessage {
     // Common
     public static final String USER_IS_NULL = "User가 null 입니다.";
     public static final String USER_ID_IS_NULL = "회원 Id를 입력해주세요.";
-    public static final String USER_NOT_EXISTING = "회원 Id에 해당하는 회원이 없습니다.";
+    public static final String USER_NOT_EXISTING = "존재하지 않는 사용자입니다.";
     public static final String USER_ALREADY_DELETED = "이미 삭제된 사용자입니다.";
     public static final String USER_ID_NOT_EQUALS_LOGIN_ID = "로그인한 사용자의 Id가 프로필 회원 Id와 일치하지 않습니다.";
 

--- a/src/test/java/sixgaezzang/sidepeek/auth/service/AuthServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.USER_NOT_EXISTING;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
@@ -93,7 +94,7 @@ class AuthServiceTest {
 
             // then
             assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(login)
-                .withMessage("존재하지 않는 사용자입니다.");
+                .withMessage(USER_NOT_EXISTING);
         }
 
         @Test
@@ -138,7 +139,7 @@ class AuthServiceTest {
 
             // then
             assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(loadUser)
-                .withMessage("존재하지 않는 사용자입니다.");
+                .withMessage(USER_NOT_EXISTING);
         }
     }
 
@@ -207,7 +208,7 @@ class AuthServiceTest {
 
             // then
             assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(reissue)
-                .withMessage("존재하지 않는 사용자입니다.");
+                .withMessage(USER_NOT_EXISTING);
         }
     }
 


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves  #142 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] UserSummary, UserProfileResponse에 isSocialLogin 추가

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 테스트 코드에는 반영을 못했습니다! 
- 브랜치가 꼬여서,,, [refactor/#130-seperate-project-save-method](https://github.com/side-peek/sidepeek_backend/tree/refactor/%23130-seperate-project-save-method)에서 브랜치를 만들어버렸습니다... 참고만 해주시면 감사하겠습니다!