### PR TITLE
프로젝트 상세 조회 시 누락된 댓글 수 및 댓글 관련 응답 객체 수정

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/comments/dto/response/CommentWithCountResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/dto/response/CommentWithCountResponse.java
@@ -1,0 +1,19 @@
+package sixgaezzang.sidepeek.comments.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CommentWithCountResponse(
+    List<CommentResponse> results,
+    Long commentCount
+) {
+
+    public static CommentWithCountResponse from(List<CommentResponse> comments, Long commentCount) {
+        return CommentWithCountResponse.builder()
+            .results(comments)
+            .commentCount(commentCount)
+            .build();
+    }
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
@@ -14,7 +14,6 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
@@ -34,6 +34,11 @@ public class CommentService {
 
     private List<ReplyResponse> mapReplies(Comment comment) {
         List<Comment> replies = commentRepository.findAllReplies(comment);
+
+        if (replies.isEmpty()) {
+            return null;    // 대댓글이 없는 경우 null 반환
+        }
+
         return replies.stream()
             .map(reply -> {
                 boolean isOwner = isSameOwner(reply, reply.getProject());

--- a/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
@@ -1,11 +1,14 @@
 package sixgaezzang.sidepeek.comments.service;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.comments.domain.Comment;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
+import sixgaezzang.sidepeek.comments.dto.response.CommentWithCountResponse;
 import sixgaezzang.sidepeek.comments.dto.response.ReplyResponse;
 import sixgaezzang.sidepeek.comments.repository.CommentRepository;
 import sixgaezzang.sidepeek.projects.domain.Project;
@@ -17,15 +20,26 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
 
-    public List<CommentResponse> findAll(Project project) {
+    public CommentWithCountResponse findAll(Project project) {
         List<Comment> comments = commentRepository.findAll(project);
-        return comments.stream()
+        AtomicLong commentCount = new AtomicLong((long) comments.size());    // 댓글 개수
+
+        if (comments.isEmpty()) {
+            return CommentWithCountResponse.from(null, commentCount.get()); // 댓글이 없는 경우 null 반환
+        }
+
+        List<CommentResponse> results = comments.stream()
             .map(comment -> {
                 boolean isOwner = isSameOwner(comment, project);
                 List<ReplyResponse> replies = mapReplies(comment);
+                if (Objects.nonNull(replies)) {
+                    commentCount.addAndGet(replies.size()); // 대댓글 개수 추가
+                }
                 return CommentResponse.from(comment, isOwner, replies);
             })
             .toList();
+
+        return CommentWithCountResponse.from(results, commentCount.get());
     }
 
     private boolean isSameOwner(Comment comment, Project project) {

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
@@ -5,6 +5,7 @@ import java.time.YearMonth;
 import java.util.List;
 import lombok.Builder;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
+import sixgaezzang.sidepeek.comments.dto.response.CommentWithCountResponse;
 import sixgaezzang.sidepeek.projects.domain.Project;
 
 @Schema(description = "프로젝트 상세 조회 응답")
@@ -30,6 +31,8 @@ public record ProjectResponse(
     Long viewCount,
     @Schema(description = "프로젝트 좋아요수", example = "0")
     Long likeCount,
+    @Schema(description = "프로젝트 댓글수", example = "0")
+    Long commentCount,
     @Schema(description = "프로젝트 기술 스택 목록")
     List<ProjectSkillSummary> techStacks,
     @Schema(description = "프로젝트 시작 연-월", example = "2024-02")
@@ -74,7 +77,7 @@ public record ProjectResponse(
 
     public static ProjectResponse from(Project project, List<OverviewImageSummary> overviewImageUrl,
         List<ProjectSkillSummary> techStacks, List<MemberSummary> members,
-        List<CommentResponse> comments
+        CommentWithCountResponse comments
     ) {
         return ProjectResponse.builder()
             .id(project.getId())
@@ -87,6 +90,7 @@ public record ProjectResponse(
             .deployUrl(project.getDeployUrl())
             .viewCount(project.getViewCount())
             .likeCount(project.getLikeCount())
+            .commentCount(comments.commentCount())  // 댓글 + 대댓글
             .techStacks(techStacks)
             .ownerId(project.getOwnerId())
             .startDate(project.getStartDate())
@@ -94,7 +98,7 @@ public record ProjectResponse(
             .members(members)
             .description(project.getDescription())
             .troubleShooting(project.getTroubleshooting())
-            .comments(comments)
+            .comments(comments.results())
             .build();
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
+import sixgaezzang.sidepeek.comments.dto.response.CommentWithCountResponse;
 import sixgaezzang.sidepeek.comments.service.CommentService;
 import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.like.repository.LikeRepository;
@@ -58,9 +58,11 @@ public class ProjectService {
             project.update(request);
         }
 
-        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project, request.techStacks());
+        List<ProjectSkillSummary> techStacks = projectSkillService.saveAll(project,
+            request.techStacks());
         List<MemberSummary> members = memberService.saveAll(project, request.members());
-        List<OverviewImageSummary> overviewImages = fileService.saveAll(project, request.overviewImageUrls());
+        List<OverviewImageSummary> overviewImages = fileService.saveAll(project,
+            request.overviewImageUrls());
 
         return ProjectResponse.from(project, overviewImages, techStacks, members);
     }
@@ -95,7 +97,7 @@ public class ProjectService {
 
         List<MemberSummary> members = memberService.findAllWithUser(project);
 
-        List<CommentResponse> comments = commentService.findAll(project);
+        CommentWithCountResponse comments = commentService.findAll(project);
 
         return ProjectResponse.from(project, overviewImages, techStacks, members, comments);
     }
@@ -121,7 +123,8 @@ public class ProjectService {
 
     private void validateLoginUserIncludeMembers(Long loginId, Project project) {
         memberService.findFellowMemberByProject(loginId, project)
-            .orElseThrow(() -> new InvalidAuthenticationException(ONLY_OWNER_AND_FELLOW_MEMBER_CAN_UPDATE));
+            .orElseThrow(
+                () -> new InvalidAuthenticationException(ONLY_OWNER_AND_FELLOW_MEMBER_CAN_UPDATE));
     }
 
 }

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
@@ -117,7 +117,7 @@ class ProjectServiceTest {
         user = createAndSaveUser();
         fellowMemberIds.add(0, user.getId());
         members.add(0, FakeDtoProvider.createFellowSaveMemberRequest(user.getId()));
-        
+
         List<Long> createdSkillIds = new ArrayList<>();
         for (int i = 1; i <= SKILL_COUNT; i++) {
             createdSkillIds.add(createAndSaveSkill().getId());
@@ -134,7 +134,7 @@ class ProjectServiceTest {
             User user = createAndSaveUser();
             Project project = createAndSaveProject(user);
             Comment comment = createAndSaveComment(user, project);
-            CommentResponse commentResponse = CommentResponse.from(comment, true, List.of());
+            CommentResponse commentResponse = CommentResponse.from(comment, true, null);
 
             // when
             ProjectResponse response = projectService.findById(project.getId());
@@ -348,7 +348,8 @@ class ProjectServiceTest {
             String newGithubUrl = FakeValueProvider.createUrl();
             String newDescription = FakeValueProvider.createLongText();
             SaveProjectRequest newRequest = FakeDtoProvider.createSaveProjectRequestOnlyRequired(
-                newName, newOverview, newGithubUrl, newDescription, user.getId(), techStacks, members
+                newName, newOverview, newGithubUrl, newDescription, user.getId(), techStacks,
+                members
             );
             ThrowingCallable update = () -> projectService.save(null, originalProject.id(),
                 newRequest);


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #150 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 응답에 누락된 댓글수 추가
- [x] 댓글 또는 대댓글이 없으면, 응답 객체 빈 리스트([])에서 null로 수정

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
