### PR TITLE
프로젝트 상세 조회 시 응답에 좋아요 Id 추가

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -31,7 +31,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<ProjectResponse> save(@Parameter(hidden = true) Long loginId,
-                                         SaveProjectRequest request);
+        SaveProjectRequest request);
 
     @Operation(summary = "프로젝트 상세 조회")
     @ApiResponses({
@@ -39,7 +39,7 @@ public interface ProjectControllerDoc {
         @ApiResponse(responseCode = "404", description = "NOT_FOUND", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameter(name = "id", description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
-    ResponseEntity<ProjectResponse> getById(Long id);
+    ResponseEntity<ProjectResponse> getById(@Parameter(hidden = true) Long loginId, Long projectId);
 
     @Operation(summary = "프로젝트 전체 조회")
     @ApiResponses({
@@ -65,7 +65,7 @@ public interface ProjectControllerDoc {
     })
     @Parameter(name = "id", description = "수정할 프로젝트 식별자", in = ParameterIn.PATH)
     ResponseEntity<ProjectResponse> update(@Parameter(hidden = true) Long loginId, Long projectId,
-                                           UpdateProjectRequest request);
+        UpdateProjectRequest request);
 
     @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자만 삭제가 가능합니다.")
     @ApiResponses({

--- a/src/main/java/sixgaezzang/sidepeek/common/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/resolver/LoginUserArgumentResolver.java
@@ -14,7 +14,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasLoginAnnotation = parameter.getParameterAnnotation(Login.class) != null;
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
         boolean hasLongType = parameter.getParameterType()
             .equals(Long.class);
 
@@ -29,15 +29,11 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         Authentication authentication = SecurityContextHolder.getContext()
             .getAuthentication();
 
-        if (authentication != null) {
-            Object principal = authentication.getPrincipal();
-            if (principal instanceof Long) {
-                return principal;
-            }
+        if (authentication != null && authentication.getPrincipal() instanceof Long) {
+            return authentication.getPrincipal(); // 사용자가 로그인한 경우, 로그인 ID 반환
         }
 
-        // 로그인하지 않은 경우 null 반환
-        return null;
+        return null;    // 로그인하지 않은 경우 null 반환
     }
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/like/repository/LikeRepositoryCustom.java
+++ b/src/main/java/sixgaezzang/sidepeek/like/repository/LikeRepositoryCustom.java
@@ -1,9 +1,14 @@
 package sixgaezzang.sidepeek.like.repository;
 
 import java.util.List;
+import java.util.Optional;
+import sixgaezzang.sidepeek.projects.domain.Project;
+import sixgaezzang.sidepeek.users.domain.User;
 
 public interface LikeRepositoryCustom {
 
     List<Long> findAllProjectIdsByUser(Long userId);
+
+    Optional<Long> findIdByUserAndProject(User user, Project project);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/like/repository/LikeRepositoryCustomImpl.java
+++ b/src/main/java/sixgaezzang/sidepeek/like/repository/LikeRepositoryCustomImpl.java
@@ -2,10 +2,14 @@ package sixgaezzang.sidepeek.like.repository;
 
 import static sixgaezzang.sidepeek.like.domain.QLike.like;
 
+import com.querydsl.core.types.Predicate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
+import sixgaezzang.sidepeek.projects.domain.Project;
+import sixgaezzang.sidepeek.users.domain.User;
 
 @Repository
 public class LikeRepositoryCustomImpl implements LikeRepositoryCustom {
@@ -23,5 +27,18 @@ public class LikeRepositoryCustomImpl implements LikeRepositoryCustom {
             .from(like)
             .where(like.user.id.eq(userId))
             .fetch();
+    }
+
+    @Override
+    public Optional<Long> findIdByUserAndProject(User user,
+        Project project) {
+        Predicate predicate = like.user.eq(user).and(like.project.eq(project));
+
+        return Optional.ofNullable(queryFactory
+            .select(like.id)
+            .from(like)
+            .where(predicate)
+            .fetchFirst()
+        );
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -51,9 +51,10 @@ public class ProjectController implements ProjectControllerDoc {
     @Override
     @GetMapping("/{id}")
     public ResponseEntity<ProjectResponse> getById(
-        @PathVariable Long id
+        @Login Long loginId,
+        @PathVariable(value = "id") Long projectId
     ) {
-        ProjectResponse response = projectService.findById(id);
+        ProjectResponse response = projectService.findById(loginId, projectId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/response/ProjectResponse.java
@@ -48,7 +48,9 @@ public record ProjectResponse(
     @Schema(description = "프로젝트 트러블 슈팅", example = "## 사이드픽 트러블 슈팅 Markdown")
     String troubleShooting,
     @Schema(description = "댓글 응답 정보")
-    List<CommentResponse> comments
+    List<CommentResponse> comments,
+    @Schema(description = "로그인한 사용자가 누른 좋아요 식별자")
+    Long likeId
 ) {
 
     public static ProjectResponse from(Project project, List<OverviewImageSummary> overviewImageUrl,
@@ -59,13 +61,14 @@ public record ProjectResponse(
             overviewImageUrl,
             techStacks,
             members,
-            Collections.emptyList()
+            Collections.emptyList(),
+            null
         );
     }
 
     public static ProjectResponse from(Project project, List<OverviewImageSummary> overviewImageUrl,
         List<ProjectSkillSummary> techStacks, List<MemberSummary> members,
-        List<CommentResponse> comments
+        List<CommentResponse> comments, Long likeId
     ) {
         return ProjectResponse.builder()
             .id(project.getId())
@@ -87,6 +90,7 @@ public record ProjectResponse(
             .description(project.getDescription())
             .troubleShooting(project.getTroubleshooting())
             .comments(comments)
+            .likeId(likeId)
             .build();
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -75,7 +75,7 @@ public class ProjectService {
             .orElseThrow(() -> new EntityNotFoundException(PROJECT_NOT_EXISTING));
     }
 
-    public CursorPaginationResponse<ProjectListResponse> findByCondition(Long userId,
+    public CursorPaginationResponse<ProjectListResponse> findByCondition(Long loginId,
         CursorPaginationInfoRequest pageable) {
         // 사용자가 좋아요한 프로젝트 ID를 조회
         List<Long> likedProjectIds = getLikedProjectIds(loginId);

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -78,9 +78,7 @@ public class ProjectService {
     public CursorPaginationResponse<ProjectListResponse> findByCondition(Long userId,
         CursorPaginationInfoRequest pageable) {
         // 사용자가 좋아요한 프로젝트 ID를 조회
-        List<Long> likedProjectIds =
-            (userId != null) ? likeRepository.findAllProjectIdsByUser(userId)
-                : Collections.emptyList();
+        List<Long> likedProjectIds = getLikedProjectIds(loginId);
 
         return projectRepository.findByCondition(likedProjectIds, pageable);
     }

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -8,7 +8,6 @@ import static sixgaezzang.sidepeek.projects.exception.message.ProjectErrorMessag
 import static sixgaezzang.sidepeek.projects.util.DateUtils.getEndDayOfLastWeek;
 import static sixgaezzang.sidepeek.projects.util.DateUtils.getStartDayOfLastWeek;
 import static sixgaezzang.sidepeek.projects.util.ProjectConstant.BANNER_PROJECT_COUNT;
-import static sixgaezzang.sidepeek.users.exception.message.UserErrorMessage.USER_NOT_EXISTING;
 import static sixgaezzang.sidepeek.users.util.validation.UserValidator.validateLoginIdEqualsUserId;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -43,7 +42,7 @@ import sixgaezzang.sidepeek.projects.dto.response.ProjectResponse;
 import sixgaezzang.sidepeek.projects.dto.response.ProjectSkillSummary;
 import sixgaezzang.sidepeek.projects.repository.project.ProjectRepository;
 import sixgaezzang.sidepeek.users.domain.User;
-import sixgaezzang.sidepeek.users.repository.UserRepository;
+import sixgaezzang.sidepeek.users.service.UserService;
 
 @Service
 @RequiredArgsConstructor
@@ -52,7 +51,7 @@ public class ProjectService {
 
     private final DateTimeProvider dateTimeProvider;
     private final ProjectRepository projectRepository;
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final ProjectSkillService projectSkillService;
     private final MemberService memberService;
     private final FileService fileService;
@@ -121,8 +120,7 @@ public class ProjectService {
 
     public Page<ProjectListResponse> findByUser(Long userId, Long loginId,
         UserProjectSearchType type, Pageable pageable) {
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new EntityNotFoundException(USER_NOT_EXISTING));
+        User user = userService.getById(userId);
 
         List<Long> likedProjectIds = getLikedProjectIds(userId);
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -66,7 +66,7 @@ public class ProjectService {
         Project project = request.toEntity();
         projectRepository.save(project);
 
-        return GetProjectResponseAfterSaveLists(project, request.techStacks(), request.members(),
+        return getProjectResponseAfterSaveLists(project, request.techStacks(), request.members(),
             request.overviewImageUrls());
     }
 
@@ -145,7 +145,7 @@ public class ProjectService {
 
         project.update(request);
 
-        return GetProjectResponseAfterSaveLists(project, request.techStacks(), request.members(),
+        return getProjectResponseAfterSaveLists(project, request.techStacks(), request.members(),
             request.overviewImageUrls());
     }
 
@@ -188,7 +188,7 @@ public class ProjectService {
         return Page.from(projectRepository.findAllByUserCommented(likedProjectIds, user, pageable));
     }
 
-    private ProjectResponse GetProjectResponseAfterSaveLists(Project project,
+    private ProjectResponse getProjectResponseAfterSaveLists(Project project,
         List<SaveTechStackRequest> request,
         List<SaveMemberRequest> request1,
         List<String> request2) {

--- a/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/service/UserService.java
@@ -17,6 +17,7 @@ import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -65,6 +66,12 @@ public class UserService {
             .orElseThrow(() -> new EntityNotFoundException(USER_NOT_EXISTING));
     }
 
+    public User getByIdOrNull(Long userId) {
+        return Optional.ofNullable(userId)
+            .map(this::getById)
+            .orElse(null);
+    }
+
     public UserSearchResponse searchByNickname(String keyword) {
         if (Objects.isNull(keyword) || keyword.isBlank()) {
             return UserSearchResponse.from(userRepository.findAll());
@@ -105,7 +112,7 @@ public class UserService {
 
     @Transactional
     public UserProfileResponse updateProfile(Long loginId, Long id,
-                                             UpdateUserProfileRequest request) {
+        UpdateUserProfileRequest request) {
         validateLoginIdEqualsUserId(loginId, id);
 
         User user = findUserById(id);


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #171 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 프로젝트 상세 조회 응답에 likeId 추가
- [x] 프로젝트 상세 조회 테스트 코드에 로직 추가
- [x] 프로젝트 service 코드 부분 리팩토링

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
로그인한 사용자가 해당 프로젝트에 좋아요를 눌렀다면 likeId = 1, 사용자가 로그인하지 않았거나 좋아요를 누르지 않은 프로젝트라면 null을 반환합니다!
