### PR TITLE
사용하지 않는 fileType 필드 제거

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/projects/domain/file/File.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/domain/file/File.java
@@ -3,11 +3,8 @@ package sixgaezzang.sidepeek.projects.domain.file;
 import static sixgaezzang.sidepeek.projects.util.validation.FileValidator.validateFileUrl;
 import static sixgaezzang.sidepeek.projects.util.validation.ProjectValidator.validateProject;
 
-import io.jsonwebtoken.lang.Assert;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,24 +32,18 @@ public class File {
     @JoinColumn(name = "project_id")
     private Project project;
 
-    @Column(name = "type", nullable = false, length = 30, columnDefinition = "VARCHAR")
-    @Enumerated(EnumType.STRING)
-    private FileType type;
-
     @Column(name = "url", nullable = false, columnDefinition = "TEXT")
     private String url;
 
     @Builder
-    public File(Project project, FileType type, String url) {
-        validateConstructorArguments(project, type, url);
+    public File(Project project, String url) {
+        validateConstructorArguments(project, url);
         this.project = project;
-        this.type = type;
         this.url = url;
     }
 
-    private void validateConstructorArguments(Project project, FileType type, String url) {
+    private void validateConstructorArguments(Project project, String url) {
         validateProject(project);
-        Assert.notNull(type, "type을 입력해주세요.");
         validateFileUrl(url);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/domain/file/FileType.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/domain/file/FileType.java
@@ -1,7 +1,0 @@
-package sixgaezzang.sidepeek.projects.domain.file;
-
-public enum FileType {
-    OVERVIEW_IMAGE,
-    DESCRIPTION_IMAGE,
-    TROUBLE_SHOOTING_IMAGE
-}

--- a/src/main/java/sixgaezzang/sidepeek/projects/repository/FileRepository.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/repository/FileRepository.java
@@ -4,14 +4,13 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.file.File;
-import sixgaezzang.sidepeek.projects.domain.file.FileType;
 
 public interface FileRepository extends JpaRepository<File, Long> {
 
-    List<File> findAllByProjectAndType(Project project, FileType type);
+    List<File> findAllByProject(Project project);
 
     boolean existsByProject(Project project);
 
-    void deleteAllByProjectAndType(Project project, FileType type);
+    void deleteAllByProject(Project project);
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/FileService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/FileService.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.file.File;
-import sixgaezzang.sidepeek.projects.domain.file.FileType;
 import sixgaezzang.sidepeek.projects.dto.response.OverviewImageSummary;
 import sixgaezzang.sidepeek.projects.repository.FileRepository;
 
@@ -43,13 +42,13 @@ public class FileService {
             .toList();
     }
 
-    public List<File> findAllByType(Project project, FileType fileType) {
-        return fileRepository.findAllByProjectAndType(project, fileType);
+    public List<File> findAll(Project project) {
+        return fileRepository.findAllByProject(project);
     }
 
     private void cleanExistingFilesByProject(Project project) {
         if (fileRepository.existsByProject(project)) {
-            fileRepository.deleteAllByProjectAndType(project, FileType.OVERVIEW_IMAGE);
+            fileRepository.deleteAllByProject(project);
         }
     }
 
@@ -57,7 +56,6 @@ public class FileService {
         return File.builder()
             .project(project)
             .url(overviewImage)
-            .type(FileType.OVERVIEW_IMAGE)
             .build();
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/FileService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/FileService.java
@@ -42,7 +42,7 @@ public class FileService {
             .toList();
     }
 
-    public List<File> findAll(Project project) {
+    public List<File> findAllByProject(Project project) {
         return fileRepository.findAllByProject(project);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -89,7 +89,7 @@ public class ProjectService {
 
         project.increaseViewCount();
 
-        List<OverviewImageSummary> overviewImages = fileService.findAll(project)
+        List<OverviewImageSummary> overviewImages = fileService.findAllByProject(project)
             .stream()
             .map(OverviewImageSummary::from)
             .toList();

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -29,7 +29,6 @@ import sixgaezzang.sidepeek.common.util.component.DateTimeProvider;
 import sixgaezzang.sidepeek.like.repository.LikeRepository;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.UserProjectSearchType;
-import sixgaezzang.sidepeek.projects.domain.file.FileType;
 import sixgaezzang.sidepeek.projects.dto.request.CursorPaginationInfoRequest;
 import sixgaezzang.sidepeek.projects.dto.request.SaveMemberRequest;
 import sixgaezzang.sidepeek.projects.dto.request.SaveProjectRequest;
@@ -90,8 +89,7 @@ public class ProjectService {
 
         project.increaseViewCount();
 
-        List<OverviewImageSummary> overviewImages = fileService.findAllByType(
-                project, FileType.OVERVIEW_IMAGE)
+        List<OverviewImageSummary> overviewImages = fileService.findAll(project)
             .stream()
             .map(OverviewImageSummary::from)
             .toList();

--- a/src/main/resources/db/data/afterMigrate.sql
+++ b/src/main/resources/db/data/afterMigrate.sql
@@ -257,10 +257,10 @@ insert into project_member(id, project_id, user_id, role, nickname)
 values (32, 30, 1, 'BE', '의진');
 
 -- FILE
-insert into files(id, project_id, type, url)
-values (1, 1, 'OVERVIEW_IMAGE', 'https://project-images.sidepeek.com/1.png');
-insert into files(id, project_id, type, url)
-values (2, 1, 'OVERVIEW_IMAGE', 'https://project-images.sidepeek.com/2.png');
+insert into files(id, project_id, url)
+values (1, 1, 'https://project-images.sidepeek.com/1.png');
+insert into files(id, project_id, url)
+values (2, 1, 'https://project-images.sidepeek.com/2.png');
 
 -- SKILL
 insert into skill(id, name, icon_image_url)

--- a/src/main/resources/db/migration/V5__delete_file_type.sql
+++ b/src/main/resources/db/migration/V5__delete_file_type.sql
@@ -1,0 +1,3 @@
+-- FILES
+ALTER TABLE files
+    DROP COLUMN type;

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/FileServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/FileServiceTest.java
@@ -128,12 +128,12 @@ class FileServiceTest {
         void 기존_프로젝트_파일_목록을_지우고_파일_목록_수정에_성공한다() {
             // given
             fileService.cleanAndSaveAll(project, imageUrls);
-            List<File> originalFiles = fileService.findAll(project);
+            List<File> originalFiles = fileService.findAllByProject(project);
 
             // when
             List<String> emptyFile = Collections.emptyList();
             fileService.cleanAndSaveAll(project, emptyFile);
-            List<File> savedFiles = fileService.findAll(project);
+            List<File> savedFiles = fileService.findAllByProject(project);
 
             // then
             assertThat(originalFiles).isNotEqualTo(savedFiles);

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/FileServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/FileServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.domain.file.File;
-import sixgaezzang.sidepeek.projects.domain.file.FileType;
 import sixgaezzang.sidepeek.projects.dto.response.OverviewImageSummary;
 import sixgaezzang.sidepeek.projects.repository.FileRepository;
 import sixgaezzang.sidepeek.projects.repository.project.ProjectRepository;
@@ -129,12 +128,12 @@ class FileServiceTest {
         void 기존_프로젝트_파일_목록을_지우고_파일_목록_수정에_성공한다() {
             // given
             fileService.cleanAndSaveAll(project, imageUrls);
-            List<File> originalFiles = fileService.findAllByType(project, FileType.OVERVIEW_IMAGE);
+            List<File> originalFiles = fileService.findAll(project);
 
             // when
             List<String> emptyFile = Collections.emptyList();
             fileService.cleanAndSaveAll(project, emptyFile);
-            List<File> savedFiles = fileService.findAllByType(project, FileType.OVERVIEW_IMAGE);
+            List<File> savedFiles = fileService.findAll(project);
 
             // then
             assertThat(originalFiles).isNotEqualTo(savedFiles);


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #117 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 사용하지 않는 fileType 필드 제거
- [x] V5 sql 설정

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 현재 프로젝트에서 관리하는 파일은 크게 `페이지 상단의 오버뷰 이미지`와 `기능설명/트러블 슈팅 글 안의 이미지` 두 종류인데 그 중에서 오버뷰 이미지는 따로 테이블에서 관리하고 있습니다! 
  - 테이블에서 관리하는 이미지가 오버뷰 이미지만 있기 때문에 현재는 file type으로 구분하지 않아도 되어서 구조를 더 단순하게 하고자 현재 상황에 맞추어 제거했습니다!