### PR TITLE
dev 서버 Sentry 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,6 @@ jacocoTestCoverageVerification {
 sentry {
     includeSourceContext = true
     org = "SENTRY_ORG"
-    projectName = "DEV_SENTRY_PROJECT_NAME"
+    projectName = "SENTRY_PROJECT_NAME"
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,4 @@ jacocoTestCoverageVerification {
 // Sentry
 sentry {
     includeSourceContext = true
-    org = System.getenv("SENTRY_ORG")
-    projectName = System.getenv("SENTRY_PROJECT_NAME")
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'checkstyle'
     id 'jacoco'
+    id "io.sentry.jvm.gradle" version "4.3.1"
 }
 
 group = 'sixgaezzang'
@@ -62,6 +63,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Sentry
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.6.0'
+    implementation 'io.sentry:sentry-jdbc:7.6.0'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -147,4 +152,12 @@ jacocoTestCoverageVerification {
     }
 
     dependsOn jacocoTestReport
+}
+
+// Sentry
+sentry {
+    includeSourceContext = true
+    org = "SENTRY_ORG"
+    projectName = "DEV_SENTRY_PROJECT_NAME"
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'checkstyle'
     id 'jacoco'
-    id "io.sentry.jvm.gradle" version "4.3.1"
 }
 
 group = 'sixgaezzang'
@@ -152,12 +151,4 @@ jacocoTestCoverageVerification {
     }
 
     dependsOn jacocoTestReport
-}
-
-// Sentry
-sentry {
-    includeSourceContext = true
-    org = System.getenv("SENTRY_ORG")
-    projectName = System.getenv("SENTRY_PROJECT_NAME")
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,4 +157,7 @@ jacocoTestCoverageVerification {
 // Sentry
 sentry {
     includeSourceContext = true
+    org = System.getenv("SENTRY_ORG")
+    projectName = System.getenv("SENTRY_PROJECT_NAME")
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ jacocoTestCoverageVerification {
 // Sentry
 sentry {
     includeSourceContext = true
-    org = "SENTRY_ORG"
-    projectName = "SENTRY_PROJECT_NAME"
+    org = System.getenv("SENTRY_ORG")
+    projectName = System.getenv("SENTRY_PROJECT_NAME")
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package sixgaezzang.sidepeek.common.exception;
 
+import io.sentry.Sentry;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -82,7 +83,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidAuthenticationException(
         InvalidAuthenticationException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
-        log.warn(e.getMessage(), e.fillInStackTrace());
+        Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(errorResponse);
@@ -103,7 +104,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleTokenValidationFailException(
         TokenValidationFailException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
-        log.warn(e.getMessage(), e.fillInStackTrace());
+        Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(errorResponse);
@@ -112,7 +113,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN, e.getMessage());
-        log.warn(e.getMessage(), e.fillInStackTrace());
+        Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(errorResponse);
@@ -122,7 +123,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
             e.getMessage());
-        log.error(e.getMessage(), e.fillInStackTrace());
+        Sentry.captureException(e);
 
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -83,6 +83,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidAuthenticationException(
         InvalidAuthenticationException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
+        log.error(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -104,6 +105,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleTokenValidationFailException(
         TokenValidationFailException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
+        log.warn(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -113,6 +115,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN, e.getMessage());
+        log.warn(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
@@ -123,6 +126,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
             e.getMessage());
+        log.error(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
         return ResponseEntity

--- a/src/main/java/sixgaezzang/sidepeek/media/exception/MediaExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/media/exception/MediaExceptionHandler.java
@@ -4,6 +4,7 @@ import static sixgaezzang.sidepeek.media.exception.message.MediaErrorMessage.CAN
 import static sixgaezzang.sidepeek.media.exception.message.MediaErrorMessage.CONTENT_TYPE_IS_UNSUPPORTED;
 import static sixgaezzang.sidepeek.media.exception.message.MediaErrorMessage.FILE_IS_EMPTY;
 
+import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -27,6 +28,7 @@ public class MediaExceptionHandler {
         HttpMediaTypeNotSupportedException e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST,
             CONTENT_TYPE_IS_UNSUPPORTED);
+        log.debug(e.getMessage(), e.fillInStackTrace());
 
         return ResponseEntity.badRequest()
             .body(errorResponse);
@@ -36,6 +38,7 @@ public class MediaExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMultipartRequestExceptions(Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST,
             FILE_IS_EMPTY);
+        log.debug(e.getMessage(), e.fillInStackTrace());
 
         return ResponseEntity.badRequest()
             .body(errorResponse);
@@ -43,9 +46,9 @@ public class MediaExceptionHandler {
 
     @ExceptionHandler(S3Exception.class)
     public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception e) {
-        log.error(e.getMessage(), e.fillInStackTrace());
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_GATEWAY,
             CANNOT_READ_FILE);
+        Sentry.captureException(e);
 
         return ResponseEntity
             .status(HttpStatus.BAD_GATEWAY)

--- a/src/main/java/sixgaezzang/sidepeek/media/exception/MediaExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/media/exception/MediaExceptionHandler.java
@@ -48,6 +48,7 @@ public class MediaExceptionHandler {
     public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_GATEWAY,
             CANNOT_READ_FILE);
+        log.error(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
         return ResponseEntity

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,1 @@
+modulelist=com.p6spy.engine.spy.P6SpyFactory


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #175 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
### dev 서버 Sentry 설정
- [x] 기존 warn 레벨 이상 예외들은 로그와 함께 Sentry로 알림 보내도록 설정
- [x] sentry-jdbc 의존성 추가로 SQL 쿼리도 인터셉트하여 sentry에서 분석할 수 있도록 설정
- [x] 위 설정을 위한 sidepeek_backend_sacret dev 변경

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 블로그 기록: [[Spring] 서버에 Sentry를 적용해보자](https://medium.com/@Hailey24/spring-dev-%EC%84%9C%EB%B2%84%EC%97%90-sentry%EB%A5%BC-%EC%A0%81%EC%9A%A9%ED%95%B4%EB%B3%B4%EC%9E%90-1-100ab28a3fa8)
- sentry가 여러명으로 팀 구성하면 유료 요금제를 내야하더라구요... 그래서 아래 두 가지 방안을 생각해보았습니다! 둘 다 저는 상관 없으니 편하게 이야기 해주세요!
  - 무료 요금제로 한 명이 대표로 Sentry 관리하기
  - 유료 요금제 체험판으로 2주동안 다같이 자유롭게 사용하기. 단 2주(약 13일..?)가 지나면 다시 개인 관리ㅠㅠ
- 참고로 정말 야속하게도 sentry로 직접 슬랙 연동해서 알림 보내는 것은 유료더라구요...ㅠㅠ 그래서 서버에 직접 슬랙을 연동하는 방법밖에 없어서 이 부분은 이어서 제가 찾아보도록 하겠습니다! 😭
