### PR TITLE
댓글 조회시 isOwner 오류

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
+++ b/src/main/java/sixgaezzang/sidepeek/comments/service/CommentService.java
@@ -68,13 +68,13 @@ public class CommentService {
             .orElseThrow(() -> new EntityNotFoundException(message));
     }
 
-    public List<CommentResponse> findAll(Project project) {
+    public List<CommentResponse> findAll(Long loginId, Project project) {
         List<Comment> comments = commentRepository.findAll(project);
 
         return comments.stream()
             .map(comment -> {
-                boolean isOwner = isSameOwner(comment, project);
-                List<ReplyResponse> replies = mapReplies(comment);
+                boolean isOwner = isSameOwner(comment, loginId);
+                List<ReplyResponse> replies = mapReplies(comment, loginId);
                 return CommentResponse.from(comment, isOwner, replies);
             })
             .toList();
@@ -105,16 +105,16 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
-    private boolean isSameOwner(Comment comment, Project project) {
-        return comment.getOwnerId().equals(project.getOwnerId());
+    private boolean isSameOwner(Comment comment, Long userId) {
+        return comment.getOwnerId().equals(userId);
     }
 
-    private List<ReplyResponse> mapReplies(Comment comment) {
+    private List<ReplyResponse> mapReplies(Comment comment, Long userId) {
         List<Comment> replies = commentRepository.findAllReplies(comment);
 
         return replies.stream()
             .map(reply -> {
-                boolean isOwner = isSameOwner(reply, reply.getProject());
+                boolean isOwner = isSameOwner(reply, userId);
                 return ReplyResponse.from(reply, isOwner);
             })
             .toList();

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -101,7 +101,7 @@ public class ProjectService {
 
         List<MemberSummary> members = memberService.findAllWithUser(project);
 
-        List<CommentResponse> comments = commentService.findAll(project);
+        List<CommentResponse> comments = commentService.findAll(loginId, project);
 
         // 로그인한 사용자가 좋아요한 프로젝트라면, 좋아요 식별자 반환(아니라면 null)
         User user = userService.getByIdOrNull(loginId);

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
@@ -203,7 +203,7 @@ class ProjectServiceTest {
             CommentResponse commentResponse = CommentResponse.from(comment, true, List.of());
 
             // when
-            ProjectResponse response = projectService.findById(null, project.getId());
+            ProjectResponse response = projectService.findById(user.getId(), project.getId());
 
             // then
             assertThat(response).extracting("id", "ownerId", "viewCount", "comments", "likeId")


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Fixes #179 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 댓글 조회시 isOwner 오류 => 로그인 id와 댓글 소유자 id 비교하여 본인 댓글인 경우 isOwner=true 보이도록 수정

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
