### PR TITLE
프로젝트 상세 조회 시 조회수 어뷰징 버그 해결

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/common/annotation/Ip.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/annotation/Ip.java
@@ -1,0 +1,12 @@
+package sixgaezzang.sidepeek.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Ip {
+
+}

--- a/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/doc/ProjectControllerDoc.java
@@ -62,7 +62,8 @@ public interface ProjectControllerDoc {
             content = @Content(examples = @ExampleObject(value = NOT_FOUND_RESPONSE)))
     })
     @Parameter(name = "id", description = "조회할 프로젝트 식별자", in = ParameterIn.PATH)
-    ResponseEntity<ProjectResponse> getById(@Parameter(hidden = true) Long loginId, Long projectId);
+    ResponseEntity<ProjectResponse> getById(@Parameter(hidden = true) String ip,
+        @Parameter(hidden = true) Long loginId, Long projectId);
 
     @Operation(summary = "프로젝트 전체 조회", description = "프로젝트 게시글 목록을 조건에 따라 조회(커서 기반 페이지네이션), 로그인 선택")
     @ApiResponses({

--- a/src/main/java/sixgaezzang/sidepeek/common/resolver/IpArgumentResolver.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/resolver/IpArgumentResolver.java
@@ -1,0 +1,37 @@
+package sixgaezzang.sidepeek.common.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import sixgaezzang.sidepeek.common.annotation.Ip;
+import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
+
+public class IpArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasIpAnnotation = parameter.hasParameterAnnotation(Ip.class);
+        boolean hasStringType = parameter.getParameterType()
+            .equals(String.class);
+
+        return hasIpAnnotation && hasStringType;
+    }
+
+    @Override
+    public Object resolveArgument(
+        MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) throws InvalidAuthenticationException {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String ip = request.getHeader("X-Forwarded-For");   // 클라이언트가 서버로 전달되는 IP 주소를 포함
+
+        if (ip != null && !ip.isBlank()) {
+            return ip.split(",")[0].trim(); // IP 주소 목록에서 첫 번째 IP 주소인 실제 클라이언트 IP 주소를 반환
+        }
+
+        return request.getRemoteAddr(); // 요청의 원격 주소를 가져와 반환
+    }
+}

--- a/src/main/java/sixgaezzang/sidepeek/config/RedisConfig.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import sixgaezzang.sidepeek.config.properties.RedisProperties;
 
 @Configuration
@@ -28,6 +29,9 @@ public class RedisConfig {
     public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
         return template;
     }
+
 }

--- a/src/main/java/sixgaezzang/sidepeek/config/WebConfig.java
+++ b/src/main/java/sixgaezzang/sidepeek/config/WebConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import sixgaezzang.sidepeek.common.resolver.IpArgumentResolver;
 import sixgaezzang.sidepeek.common.resolver.LoginUserArgumentResolver;
 
 @Configuration
@@ -12,6 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new LoginUserArgumentResolver());
+        resolvers.add(new IpArgumentResolver());
     }
 
 }

--- a/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/controller/ProjectController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import sixgaezzang.sidepeek.common.annotation.Ip;
 import sixgaezzang.sidepeek.common.annotation.Login;
 import sixgaezzang.sidepeek.common.doc.ProjectControllerDoc;
 import sixgaezzang.sidepeek.projects.dto.request.FindProjectRequest;
@@ -51,10 +52,11 @@ public class ProjectController implements ProjectControllerDoc {
     @Override
     @GetMapping("/{id}")
     public ResponseEntity<ProjectResponse> getById(
+        @Ip String ip,
         @Login Long loginId,
         @PathVariable(value = "id") Long projectId
     ) {
-        ProjectResponse response = projectService.findById(loginId, projectId);
+        ProjectResponse response = projectService.findById(ip, loginId, projectId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
@@ -198,12 +198,13 @@ class ProjectServiceTest {
         @Test
         void 사용자가_로그인하지_않아도_프로젝트_상세_조회를_성공한다() {
             // given
+            String ip = "localhost";
             Project project = createAndSaveProject(user);
             Comment comment = createAndSaveComment(user, project, null);
             CommentResponse commentResponse = CommentResponse.from(comment, true, List.of());
 
             // when
-            ProjectResponse response = projectService.findById(user.getId(), project.getId());
+            ProjectResponse response = projectService.findById(ip, user.getId(), project.getId());
 
             // then
             assertThat(response).extracting("id", "ownerId", "viewCount", "comments", "likeId")
@@ -214,12 +215,13 @@ class ProjectServiceTest {
         @Test
         void 로그인한_사용자가_프로젝트_상세_조회를_성공한다() {
             // given
+            String ip = "localhost";
             Project project = createAndSaveProject(user);
             Comment comment = createAndSaveComment(user, project, null);
             CommentResponse commentResponse = CommentResponse.from(comment, true, List.of());
 
             // when
-            ProjectResponse response = projectService.findById(user.getId(), project.getId());
+            ProjectResponse response = projectService.findById(ip, user.getId(), project.getId());
 
             // then
             assertThat(response).extracting("id", "ownerId", "viewCount", "comments", "likeId")
@@ -229,6 +231,7 @@ class ProjectServiceTest {
         @Test
         void 로그인한_사용자가_좋아요한_프로젝트_상세_조회를_성공한다() {
             // given
+            String ip = "localhost";
             Project project = createAndSaveProject(user);
             Comment comment = createAndSaveComment(user, project, null);
             CommentResponse commentResponse = CommentResponse.from(comment, true, List.of());
@@ -236,7 +239,7 @@ class ProjectServiceTest {
                 user);   // 사용자가 프로젝트에 좋아요를 누르면 상세 조회 시 좋아요 식별자 반환
 
             // when
-            ProjectResponse response = projectService.findById(user.getId(), project.getId());
+            ProjectResponse response = projectService.findById(ip, user.getId(), project.getId());
 
             // then
             assertThat(response).extracting("id", "ownerId", "viewCount", "comments", "likeId")
@@ -247,10 +250,11 @@ class ProjectServiceTest {
         @Test
         void 프로젝트_ID가_존재하지_않으면_프로젝트_상세_조회를_실패한다() {
             // given
+            String ip = "localhost";
             Long invalidId = faker.random().nextLong(Long.MAX_VALUE);
 
             // when
-            ThrowingCallable findById = () -> projectService.findById(user.getId(), invalidId);
+            ThrowingCallable findById = () -> projectService.findById(ip, user.getId(), invalidId);
 
             // then
             assertThatExceptionOfType(EntityNotFoundException.class).isThrownBy(findById)
@@ -741,6 +745,7 @@ class ProjectServiceTest {
         void 프로젝트_소프트_삭제에_성공한다() {
             // given
             given(dateTimeProvider.getCurrentDateTime()).willReturn(LocalDateTime.now());
+            String ip = "localhost";
             ProjectResponse project = getNewSavedProject(user.getId());
 
             // when
@@ -748,7 +753,7 @@ class ProjectServiceTest {
 
             // TODO: @SQLRestriction("deleted_at IS NULL")이 안먹힌다. 왜지?
             Optional<Project> deletedProject = projectRepository.findById(project.id());
-            projectService.findById(user.getId(), project.id());
+            projectService.findById(ip, user.getId(), project.id());
 
             // then
             assertThat(deletedProject).isNotEmpty();


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #177 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] IP 어노테이션 및 리졸버 구현
- [x] RedisTemplate에 직렬화 및 트랜잭션 기능 추가
- [x] 프로젝트 상세 조회 api 엔드포인트에 @IP 적용
- [x] 프로젝트 상세 조회 service에 조회수 관련 로직 수정

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
`기존의 조회수 정책`은 프로젝트를 상세 조회할 때마다 **조회수가 무조건 증가하는 방식**으로 구현되어 있었습니다. 그러나 이 방법은 프로젝트, 댓글, 좋아요를 생성, 수정, 삭제한 후에 다시 프로젝트를 조회할 때 조회수가 다시 증가하는 문제가 발생했습니다. 

이 문제를 해결하기 위해, 회원이든 비회원이든 요청하는 IP 주소를 가져와 프로젝트 ID로 key를 만들어 **Redis**에 저장하는 방식으로 변경했습니다. 이 방식을 통해 **동일한 IP로 `당일`에 이미 조회한 상세 프로젝트라면 조회수를 증가하지 않도록** 설정했습니다.