### PR TITLE
소셜 로그인 시 닉네임이 이미 우리 서비스에 존재하는 경우 예외를 발생시키는 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,5 @@ docker/redis/data/
 
 # Ignore QueryDSL generated files
 /src/main/generated/
+
+src/main/resources/application.yml

--- a/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/GithubUserInfoMapper.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/GithubUserInfoMapper.java
@@ -1,8 +1,13 @@
 package sixgaezzang.sidepeek.auth.oauth.service.strategy;
 
-import java.util.Map;
-import sixgaezzang.sidepeek.users.domain.User;
+import static java.util.Objects.isNull;
 
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import sixgaezzang.sidepeek.users.domain.User;
+import sixgaezzang.sidepeek.users.service.UserService;
+
+@RequiredArgsConstructor
 public class GithubUserInfoMapper implements UserInfoMapper {
 
     private static final String ATTRIBUTE_ID = "id";
@@ -12,17 +17,18 @@ public class GithubUserInfoMapper implements UserInfoMapper {
     private static final String ATTRIBUTE_BLOG_URL = "blog";
     private static final String ATTRIBUTE_PROFILE_IMAGE_URL = "avatar_url";
 
+
+    private final UserService userService;
+
     @Override
     public User mapToUser(Map<String, Object> attributes) {
-        User user = User.builder()
-            .email(getAttribute(attributes, ATTRIBUTE_EMAIL))
-            .nickname(getAttribute(attributes, ATTRIBUTE_NICKNAME))
+        return User.builder()
+            .email(getEmail(attributes))
+            .nickname(getNickname(attributes))
             .profileImageUrl(getAttribute(attributes, ATTRIBUTE_PROFILE_IMAGE_URL))
             .githubUrl(getAttribute(attributes, ATTRIBUTE_GITHUB_URL))
             .blogUrl(getAttribute(attributes, ATTRIBUTE_BLOG_URL))
             .build();
-
-        return user;
     }
 
     @Override
@@ -33,5 +39,25 @@ public class GithubUserInfoMapper implements UserInfoMapper {
     private String getAttribute(Map<String, Object> attributes, String key) {
         Object value = attributes.get(key);
         return value != null ? value.toString() : null;
+    }
+
+    private String getEmail(Map<String, Object> attributes) {
+        String email = getAttribute(attributes, ATTRIBUTE_EMAIL);
+
+        if (isNull(email) || userService.checkEmailDuplicate(email).isDuplicated()) {
+            return null;
+        }
+
+        return email;
+    }
+
+    private String getNickname(Map<String, Object> attributes) {
+        String nickname = getAttribute(attributes, ATTRIBUTE_NICKNAME);
+
+        if (isNull(nickname) || userService.checkNicknameDuplicate(nickname).isDuplicated()) {
+            return null;
+        }
+
+        return nickname;
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/GithubUserInfoMapper.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/GithubUserInfoMapper.java
@@ -17,7 +17,6 @@ public class GithubUserInfoMapper implements UserInfoMapper {
     private static final String ATTRIBUTE_BLOG_URL = "blog";
     private static final String ATTRIBUTE_PROFILE_IMAGE_URL = "avatar_url";
 
-
     private final UserService userService;
 
     @Override

--- a/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/UserInfoMapperFactory.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/oauth/service/strategy/UserInfoMapperFactory.java
@@ -4,15 +4,16 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 import sixgaezzang.sidepeek.auth.domain.ProviderType;
+import sixgaezzang.sidepeek.users.service.UserService;
 
 @Component
 public class UserInfoMapperFactory {
 
     private Map<ProviderType, UserInfoMapper> mappers;
 
-    public UserInfoMapperFactory() {
+    public UserInfoMapperFactory(UserService userService) {
         mappers = new HashMap<>();
-        mappers.put(ProviderType.GITHUB, new GithubUserInfoMapper());
+        mappers.put(ProviderType.GITHUB, new GithubUserInfoMapper(userService));
     }
 
     public UserInfoMapper getMapper(ProviderType providerType) {


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #207

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 소셜 로그인을 통해 회원가입이 진행되는 경우, 닉네임과 이메일 중복 검사를 하도록 변경 
- [x] 닉네임 또는 이메일이 중복되는 경우 해당 값을 null로 설정
