### PR TITLE
HttpRequestMethodNotSupportedException 핸들러 구현

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -7,10 +7,12 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -24,6 +26,18 @@ import sixgaezzang.sidepeek.common.util.component.SlackClient;
 public class GlobalExceptionHandler {
 
     private final SlackClient slackClient;
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+        HttpRequestMethodNotSupportedException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED,
+            "해당 요청에서 " + e.getMethod() + " Method는 지원하지 않습니다.");
+        log.debug(e.getMessage(), e.fillInStackTrace());
+
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+            .allow(e.getSupportedHttpMethods().toArray(new HttpMethod[0]))
+            .body(errorResponse);
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<List<ErrorResponse>> handleMethodArgumentNotValidException(


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #209 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] HttpRequestMethodNotSupportedException 핸들러 구현

<img width="401" alt="image" src="https://github.com/side-peek/sidepeek_backend/assets/85275893/303d2540-64a5-4fb0-94df-024b76be9350">

- 위 사진에 띄어쓰기는 수정이 된 상태입니다!

<img width="1189" alt="image" src="https://github.com/side-peek/sidepeek_backend/assets/85275893/c3f54c60-d20e-4596-9112-451b7c3cee66">

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 해당 에러의 핸들러가 없어서 계속 슬랙 알림이 오더라구요! 그래서 핸들러를 반영했습니다!
- [405번 http status 설명](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405)에 따라서 응답 헤더에 allow method 목록도 추가해주었습니다!