### PR TITLE
Slack 메시지에 요청 url과 메서드 확인할 수 있도록 구현

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package sixgaezzang.sidepeek.common.exception;
 import io.sentry.Sentry;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -129,11 +130,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleException(HttpServletRequest request, Exception e) {
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
             e.getMessage());
         log.error(e.getMessage(), e.fillInStackTrace());
-        slackClient.sendErrorMessage(e, Sentry.captureException(e));
+        slackClient.sendErrorMessage(e, Sentry.captureException(e), request);
 
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/sixgaezzang/sidepeek/common/util/component/SlackClient.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/util/component/SlackClient.java
@@ -14,6 +14,7 @@ import com.slack.api.model.block.SectionBlock;
 import com.slack.api.model.block.element.ButtonElement;
 import com.slack.api.model.block.element.ImageElement;
 import io.sentry.protocol.SentryId;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import sixgaezzang.sidepeek.config.properties.SentryAlertProperties;
@@ -27,21 +28,22 @@ public class SlackClient {
     private final SlackProperties slackProperties;
     private final SentryAlertProperties sentryAlertProperties;
 
-    public void sendErrorMessage(Exception exception, SentryId sentryId) {
+    public void sendErrorMessage(Exception exception, SentryId sentryId, HttpServletRequest request) {
         HeaderBlock headerBlock = header(header -> header
             .text(plainText("🚨 " + getExceptionClassName(exception) + " 감지")));
 
         SectionBlock messageSectionBlock = section(section -> section
             .text(markdownText("*Environment:* " + sentryAlertProperties.environment()
-                + "\n*Message:* " + exception.getMessage()
-                + "\n*Sentry Issue ID:* " + sentryId + "\n"))
+                + "\n*Request Method:* " + request.getMethod()
+                + "\n*Request Path:* " + request.getRequestURI()
+                + "\n*Error Message:* " + exception.getMessage()))
             .accessory(ImageElement.builder()
                 .imageUrl(slackProperties.getErrorImageUrl())
                 .altText(slackProperties.getErrorImageAlt())
                 .build()));
 
         SectionBlock linkButtonSectionBlock = section(section -> section
-            .text(markdownText("*Sentry Issue* 보러가기 \uD83D\uDC49"))
+            .text(markdownText("*Sentry Issue(ID: " + sentryId + ")* 보러가기 \uD83D\uDC49"))
             .accessory(ButtonElement.builder()
                 .text(plainText("Click 👀"))
                 .value("sentry_issue")


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #211

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] Slack 메시지에 요청 url과 메서드 확인할 수 있도록 구현

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
<img width="451" alt="image" src="https://github.com/side-peek/sidepeek_backend/assets/85275893/60bc358e-ee33-44dc-8a46-193c5c8a7805">