### PR TITLE
프로젝트 키워드로 검색 시 기술 스택으로 필터링 가능하도록 수정

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/projects/dto/request/FindProjectRequest.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/dto/request/FindProjectRequest.java
@@ -43,6 +43,7 @@ public record FindProjectRequest(
     @Nullable
     List<String> skill,
 
+    // Search
     @Schema(description = SEARCH_DESCRIPTION)
     @Nullable
     String search

--- a/src/main/java/sixgaezzang/sidepeek/projects/repository/project/ProjectRepositoryCustomImpl.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/repository/project/ProjectRepositoryCustomImpl.java
@@ -197,20 +197,20 @@ public class ProjectRepositoryCustomImpl implements ProjectRepositoryCustom {
     }
 
     private BooleanExpression getCursorCondition(SortType sort, Long lastProjectId,
-        Long orderCount) {
-        if (lastProjectId == null && orderCount == null) {  // 첫 번째 페이지
+        Long lastOrderCount) {
+        if (lastProjectId == null && lastOrderCount == null) {  // 첫 번째 페이지
             return null;
         }
 
         switch (sort) { // 다음 페이지
             case like: // 좋아요순
-                return project.likeCount.eq(orderCount)
+                return project.likeCount.eq(lastOrderCount)
                     .and(project.id.gt(lastProjectId))
-                    .or(project.likeCount.lt(orderCount));
+                    .or(project.likeCount.lt(lastOrderCount));
             case view: // 조회수순
-                return project.viewCount.eq(orderCount)
+                return project.viewCount.eq(lastOrderCount)
                     .and(project.id.gt(lastProjectId))
-                    .or(project.viewCount.lt(orderCount));
+                    .or(project.viewCount.lt(lastOrderCount));
             default: // 최신순
                 return project.id.lt(lastProjectId);
         }


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Resolves #221 

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 프로젝트 Repository getByCondition 키워드 검색과 기술스택 필터링이 동시에 가능하도록 수정
- [x] 프로젝트 Repository getTotalElements 메서드 통일

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
