### PR TITLE
refactor: 인증관련 서비스 예외 리팩토링

### DIFF
--- a/src/main/java/sixgaezzang/sidepeek/auth/exception/message/AuthErrorMessage.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/exception/message/AuthErrorMessage.java
@@ -9,6 +9,7 @@ public class AuthErrorMessage {
     public static final String EMAIL_IS_NULL = "이메일을 입력해주세요.";
     public static final String PASSWORD_IS_NULL = "비밀번호를 입력해주세요.";
     public static final String REFRESH_TOKEN_IS_NULL = "Refresh Token을 입력해주세요.";
+    public static final String TOKEN_IS_EXPIRED = "만료된 토큰입니다.";
     public static final String TOKEN_IS_INVALID = "유효하지 않은 토큰입니다.";
     public static final String PASSWORD_NOT_MATCH = "비밀번호가 일치하지 않습니다.";
     public static final String OAUTH_USER_TYPE_IS_INVALID = "유효하지 않은 OAuth 사용자 타입입니다.";

--- a/src/main/java/sixgaezzang/sidepeek/auth/filter/JWTValidationFilter.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/filter/JWTValidationFilter.java
@@ -9,13 +9,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.flywaydb.core.internal.util.StringUtils;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import sixgaezzang.sidepeek.auth.jwt.JWTManager;
+import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
 
 @Component
 @RequiredArgsConstructor
@@ -39,7 +39,7 @@ public class JWTValidationFilter extends OncePerRequestFilter {
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (Exception e) {
-                throw new BadCredentialsException(TOKEN_IS_INVALID);
+                throw new TokenValidationFailException(TOKEN_IS_INVALID);
             }
         }
 

--- a/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/jwt/JWTManager.java
@@ -1,5 +1,8 @@
 package sixgaezzang.sidepeek.auth.jwt;
 
+import static sixgaezzang.sidepeek.auth.exception.message.AuthErrorMessage.TOKEN_IS_EXPIRED;
+import static sixgaezzang.sidepeek.auth.exception.message.AuthErrorMessage.TOKEN_IS_INVALID;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -69,9 +72,9 @@ public class JWTManager {
                 .parseClaimsJws(token)
                 .getBody();
         } catch (ExpiredJwtException e) {
-            throw new TokenValidationFailException("만료된 토큰입니다.");
+            throw new TokenValidationFailException(TOKEN_IS_EXPIRED);
         } catch (Exception e) {
-            throw new TokenValidationFailException("유효하지 않은 토큰입니다.");
+            throw new TokenValidationFailException(TOKEN_IS_INVALID);
         }
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/AuthService.java
@@ -18,7 +18,7 @@ import sixgaezzang.sidepeek.auth.dto.response.LoginResponse;
 import sixgaezzang.sidepeek.auth.jwt.JWTManager;
 import sixgaezzang.sidepeek.auth.repository.AuthProviderRepository;
 import sixgaezzang.sidepeek.common.annotation.Login;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
+import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.response.UserSummary;
 import sixgaezzang.sidepeek.users.repository.UserRepository;
@@ -85,7 +85,7 @@ public class AuthService {
 
     private void validateRefreshToken(String redisRefreshToken, String refreshToken) {
         if (!redisRefreshToken.equals(refreshToken)) {
-            throw new InvalidAuthenticationException(TOKEN_IS_INVALID);
+            throw new TokenValidationFailException(TOKEN_IS_INVALID);
         }
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/auth/service/RefreshTokenService.java
+++ b/src/main/java/sixgaezzang/sidepeek/auth/service/RefreshTokenService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import sixgaezzang.sidepeek.auth.domain.RefreshToken;
 import sixgaezzang.sidepeek.auth.jwt.JWTManager;
 import sixgaezzang.sidepeek.auth.repository.RefreshTokenRepository;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
+import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,6 @@ public class RefreshTokenService {
 
     public RefreshToken getById(Long userId) {
         return refreshTokenRepository.findById(userId)
-            .orElseThrow(() -> new InvalidAuthenticationException(TOKEN_IS_INVALID));
+            .orElseThrow(() -> new TokenValidationFailException(TOKEN_IS_INVALID));
     }
 }

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -115,11 +115,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ErrorResponse> handleAuthenticationException(
         BadCredentialsException e) {
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
         log.warn(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(errorResponse);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -95,11 +95,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
         NoResourceFoundException e) {
-        String errorMessage = e.getHttpMethod() + " " + e.getResourcePath() + "라는 요청은 유효하지 않습니다.";
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage);
+        String errorMessage = e.getHttpMethod() + " /" + e.getResourcePath() + "요청은 정의되지 않아 응답할 수 없습니다.";
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, errorMessage);
         log.debug(e.getMessage(), e.fillInStackTrace());
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
             .body(errorResponse);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import sixgaezzang.sidepeek.common.util.component.SlackClient;
 
 @RestControllerAdvice
@@ -91,6 +92,17 @@ public class GlobalExceptionHandler {
             .body(errorResponse);
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+        NoResourceFoundException e) {
+        String errorMessage = e.getHttpMethod() + " " + e.getResourcePath() + "라는 요청은 유효하지 않습니다.";
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, errorMessage);
+        log.debug(e.getMessage(), e.fillInStackTrace());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorResponse);
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
         IllegalArgumentException e) {
@@ -113,13 +125,13 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+    public ResponseEntity<ErrorResponse> handleBadCredentialsException(
         BadCredentialsException e) {
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
         log.warn(e.getMessage(), e.fillInStackTrace());
         Sentry.captureException(e);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(errorResponse);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -95,7 +95,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
         NoResourceFoundException e) {
-        String errorMessage = e.getHttpMethod() + " /" + e.getResourcePath() + "요청은 정의되지 않아 응답할 수 없습니다.";
+        String errorMessage = e.getHttpMethod() + " /" + e.getResourcePath() + " 요청은 정의되지 않아 응답할 수 없습니다.";
         ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.NOT_ACCEPTABLE, errorMessage);
         log.debug(e.getMessage(), e.fillInStackTrace());
 

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -100,17 +101,6 @@ public class GlobalExceptionHandler {
             .body(errorResponse);
     }
 
-    @ExceptionHandler(InvalidAuthenticationException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidAuthenticationException(
-        InvalidAuthenticationException e) {
-        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
-        log.warn(e.getMessage(), e.fillInStackTrace());
-        Sentry.captureException(e);
-
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-            .body(errorResponse);
-    }
-
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
         HttpMessageNotReadableException e) {
@@ -119,6 +109,17 @@ public class GlobalExceptionHandler {
         log.debug(e.getMessage(), e.fillInStackTrace());
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorResponse);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(
+        BadCredentialsException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage());
+        log.warn(e.getMessage(), e.fillInStackTrace());
+        Sentry.captureException(e);
+
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
             .body(errorResponse);
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/common/exception/InvalidAuthenticationException.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/exception/InvalidAuthenticationException.java
@@ -1,9 +1,0 @@
-package sixgaezzang.sidepeek.common.exception;
-
-public class InvalidAuthenticationException extends RuntimeException {
-
-    public InvalidAuthenticationException(String message) {
-        super(message);
-    }
-
-}

--- a/src/main/java/sixgaezzang/sidepeek/common/resolver/IpArgumentResolver.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/resolver/IpArgumentResolver.java
@@ -7,7 +7,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import sixgaezzang.sidepeek.common.annotation.Ip;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 
 public class IpArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -24,7 +23,7 @@ public class IpArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(
         MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
         WebDataBinderFactory binderFactory
-    ) throws InvalidAuthenticationException {
+    ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String ip = request.getHeader("X-Forwarded-For");   // 클라이언트가 서버로 전달되는 IP 주소를 포함
 

--- a/src/main/java/sixgaezzang/sidepeek/common/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/resolver/LoginUserArgumentResolver.java
@@ -8,7 +8,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import sixgaezzang.sidepeek.common.annotation.Login;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -25,7 +24,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     public Object resolveArgument(
         MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
         WebDataBinderFactory binderFactory
-    ) throws InvalidAuthenticationException {
+    ) {
         Authentication authentication = SecurityContextHolder.getContext()
             .getAuthentication();
 

--- a/src/main/java/sixgaezzang/sidepeek/common/util/validation/ValidationUtils.java
+++ b/src/main/java/sixgaezzang/sidepeek/common/util/validation/ValidationUtils.java
@@ -26,8 +26,8 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.util.Assert;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ValidationUtils {
@@ -41,7 +41,7 @@ public final class ValidationUtils {
 
     public static void validateLoginId(Long loginId) {
         if (Objects.isNull(loginId)) {
-            throw new InvalidAuthenticationException(LOGIN_IS_REQUIRED);
+            throw new BadCredentialsException(LOGIN_IS_REQUIRED);
         }
     }
 

--- a/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
+++ b/src/main/java/sixgaezzang/sidepeek/projects/service/ProjectService.java
@@ -20,12 +20,12 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
 import sixgaezzang.sidepeek.comments.service.CommentService;
 import sixgaezzang.sidepeek.common.dto.response.Page;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.common.util.component.DateTimeProvider;
 import sixgaezzang.sidepeek.like.repository.LikeRepository;
 import sixgaezzang.sidepeek.projects.domain.Project;
@@ -178,7 +178,7 @@ public class ProjectService {
     private void validateLoginUserIncludeMembers(Long loginId, Project project) {
         memberService.findFellowMemberByProject(loginId, project)
             .orElseThrow(
-                () -> new InvalidAuthenticationException(ONLY_OWNER_AND_FELLOW_MEMBER_CAN_UPDATE));
+                () -> new AccessDeniedException(ONLY_OWNER_AND_FELLOW_MEMBER_CAN_UPDATE));
     }
 
     private List<Long> getLikedProjectIds(Long userId) {

--- a/src/main/java/sixgaezzang/sidepeek/users/util/validation/UserValidator.java
+++ b/src/main/java/sixgaezzang/sidepeek/users/util/validation/UserValidator.java
@@ -22,8 +22,8 @@ import io.micrometer.common.util.StringUtils;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.Assert;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.users.domain.User;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -43,7 +43,7 @@ public final class UserValidator {
         validateUserId(id);
 
         if (!Objects.equals(loginId, id)) {
-            throw new InvalidAuthenticationException(USER_ID_NOT_EQUALS_LOGIN_ID);
+            throw new AccessDeniedException(USER_ID_NOT_EQUALS_LOGIN_ID);
         }
     }
 

--- a/src/test/java/sixgaezzang/sidepeek/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/auth/service/RefreshTokenServiceTest.java
@@ -3,6 +3,7 @@ package sixgaezzang.sidepeek.auth.service;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static sixgaezzang.sidepeek.auth.domain.RefreshToken.MILLISECONDS_PER_SECOND;
+import static sixgaezzang.sidepeek.auth.exception.message.AuthErrorMessage.TOKEN_IS_INVALID;
 
 import net.datafaker.Faker;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -17,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.auth.domain.RefreshToken;
 import sixgaezzang.sidepeek.auth.jwt.JWTManager;
 import sixgaezzang.sidepeek.auth.repository.RefreshTokenRepository;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.common.exception.TokenValidationFailException;
 
 @SpringBootTest
@@ -69,7 +69,7 @@ class RefreshTokenServiceTest {
 
             // then
             assertThatThrownBy(saven).isInstanceOf(TokenValidationFailException.class)
-                .hasMessage("유효하지 않은 토큰입니다.");
+                .hasMessage(TOKEN_IS_INVALID);
         }
     }
 
@@ -100,8 +100,8 @@ class RefreshTokenServiceTest {
             ThrowingCallable getById = () -> refreshTokenService.getById(userId);
 
             // then
-            assertThatThrownBy(getById).isInstanceOf(InvalidAuthenticationException.class)
-                .hasMessage("유효하지 않은 토큰입니다.");
+            assertThatThrownBy(getById).isInstanceOf(TokenValidationFailException.class)
+                .hasMessage(TOKEN_IS_INVALID);
         }
     }
 

--- a/src/test/java/sixgaezzang/sidepeek/comments/service/CommentServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/comments/service/CommentServiceTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.comments.domain.Comment;
 import sixgaezzang.sidepeek.comments.dto.request.SaveCommentRequest;
 import sixgaezzang.sidepeek.comments.dto.request.UpdateCommentRequest;
 import sixgaezzang.sidepeek.comments.repository.CommentRepository;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.projects.domain.Project;
 import sixgaezzang.sidepeek.projects.repository.project.ProjectRepository;
 import sixgaezzang.sidepeek.projects.service.ProjectService;
@@ -271,7 +271,7 @@ class CommentServiceTest {
             ThrowableAssert.ThrowingCallable save = () -> commentService.save(null, request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(save)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(save)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -285,7 +285,7 @@ class CommentServiceTest {
             ThrowableAssert.ThrowingCallable save = () -> commentService.save(null, request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(save)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(save)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -384,7 +384,7 @@ class CommentServiceTest {
                 null, comment.getId(), request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(update)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(update)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -490,7 +490,7 @@ class CommentServiceTest {
                 null, comment.getId());
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(delete)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(delete)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 

--- a/src/test/java/sixgaezzang/sidepeek/like/service/LikeServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/like/service/LikeServiceTest.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.like.domain.Like;
 import sixgaezzang.sidepeek.like.dto.request.LikeRequest;
 import sixgaezzang.sidepeek.like.dto.response.LikeResponse;
@@ -105,7 +105,7 @@ class LikeServiceTest {
             ThrowingCallable save = () -> likeService.save(null, request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(save)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(save)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -192,7 +192,7 @@ class LikeServiceTest {
             ThrowingCallable delete = () -> likeService.delete(null, existingLike.getId());
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(delete)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(delete)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 

--- a/src/test/java/sixgaezzang/sidepeek/media/service/MediaServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/media/service/MediaServiceTest.java
@@ -20,9 +20,9 @@ import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.config.properties.S3Properties;
 import sixgaezzang.sidepeek.media.dto.response.MediaUploadResponse;
 import sixgaezzang.sidepeek.users.domain.User;
@@ -150,7 +150,7 @@ class MediaServiceTest {
             ThrowingCallable upload = () -> mediaService.uploadFile(null, file);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(upload)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(upload)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 

--- a/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/projects/service/ProjectServiceTest.java
@@ -57,13 +57,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
 import sixgaezzang.sidepeek.comments.domain.Comment;
 import sixgaezzang.sidepeek.comments.dto.response.CommentResponse;
 import sixgaezzang.sidepeek.comments.repository.CommentRepository;
 import sixgaezzang.sidepeek.common.dto.request.SaveTechStackRequest;
 import sixgaezzang.sidepeek.common.dto.response.Page;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.common.util.component.DateTimeProvider;
 import sixgaezzang.sidepeek.like.domain.Like;
 import sixgaezzang.sidepeek.like.repository.LikeRepository;
@@ -432,7 +432,7 @@ class ProjectServiceTest {
                 UserProjectSearchType.LIKED, Pageable.ofSize(defaultPageSize));
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(findByUser)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(findByUser)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -443,7 +443,7 @@ class ProjectServiceTest {
                 UserProjectSearchType.COMMENTED, Pageable.ofSize(defaultPageSize));
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(findByUser)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(findByUser)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -459,7 +459,7 @@ class ProjectServiceTest {
                 UserProjectSearchType.LIKED, Pageable.ofSize(defaultPageSize));
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(findByUser)
+            assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(findByUser)
                 .withMessage(USER_ID_NOT_EQUALS_LOGIN_ID);
         }
 
@@ -475,7 +475,7 @@ class ProjectServiceTest {
                 UserProjectSearchType.COMMENTED, Pageable.ofSize(defaultPageSize));
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(findByUser)
+            assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(findByUser)
                 .withMessage(USER_ID_NOT_EQUALS_LOGIN_ID);
         }
 
@@ -636,7 +636,7 @@ class ProjectServiceTest {
             ThrowingCallable save = () -> projectService.save(null, request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(save)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(save)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -711,7 +711,7 @@ class ProjectServiceTest {
                 newRequest);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(update)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(update)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 
@@ -739,7 +739,7 @@ class ProjectServiceTest {
                     originalProject.id(), newRequest);
 
                 // then
-                assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(update)
+                assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(update)
                     .withMessage(ONLY_OWNER_AND_FELLOW_MEMBER_CAN_UPDATE);
             });
         }
@@ -777,7 +777,7 @@ class ProjectServiceTest {
             ThrowingCallable delete = () -> projectService.delete(null, project.id());
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(delete)
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(delete)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
 

--- a/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
+++ b/src/test/java/sixgaezzang/sidepeek/users/service/UserServiceTest.java
@@ -40,9 +40,9 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-import sixgaezzang.sidepeek.common.exception.InvalidAuthenticationException;
 import sixgaezzang.sidepeek.users.domain.Password;
 import sixgaezzang.sidepeek.users.domain.User;
 import sixgaezzang.sidepeek.users.dto.request.SignUpRequest;
@@ -364,7 +364,7 @@ class UserServiceTest {
                 request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(
                     updateProfile)
                 .withMessage(LOGIN_IS_REQUIRED);
         }
@@ -379,7 +379,7 @@ class UserServiceTest {
                 user.getId(), request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(
+            assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(
                     updateProfile)
                 .withMessage(USER_ID_NOT_EQUALS_LOGIN_ID);
         }
@@ -536,7 +536,7 @@ class UserServiceTest {
                 user.getId(), request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(
+            assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(
                     updatePassword)
                 .withMessage(USER_ID_NOT_EQUALS_LOGIN_ID);
         }
@@ -553,7 +553,7 @@ class UserServiceTest {
                 request);
 
             // then
-            assertThatExceptionOfType(InvalidAuthenticationException.class).isThrownBy(
+            assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(
                     updatePassword)
                 .withMessage(LOGIN_IS_REQUIRED);
         }


### PR DESCRIPTION
## 🎫 관련 이슈
<!--이슈 태스크를 모두 완료하고 닫는다면 Resolves #번호-->
<!--이슈 태스크를 모두 완료하지는 못 했지만 닫는다면 Closes #번호-->
<!--이슈 태스크를 일부 완료하고 열어둔다면 Fixes #번호-->
Fixes #189

## ✅ 구현 내용
<!--빠른 리뷰를 위해 이해를 도울 만한 설명이 있다면 적어주세요!-->
- [x] 특정 예외 알림이 안 가도록 핸들러 수정
  - [x] NoResourceFoundException
  - [x]  BasCredentialsException 

- [x] 인증/인가 관련 예외 클래스 수정
  - 토큰 관련은 TokenValidationFailException => status code: unAuthorized 
  - 인증에서 토큰 관련 말고는 BasCredentialsException => status code: unAuthorized 
  - 인가(권한) 관련은 AccessDeniedException 

## 💬 코멘트
<!-- PR 올리면서 팀원들에게 공유할 사항 및 이슈가 있다면 적어주세요!-->
- 인증/인가 예외가 통일되면 더 좋을 것 같아서 조금 리팩토링해봤는데 어떠신지 여쭤봅니당!! 
- GlobalExceptionHandler에서 slack 메시지를 애너테이션을 이용해 aop 적용하여 메시징 코드만 따로 분리할 예정인데 하기 전에 예외핸들러 정리를 좀 해보려합니당!